### PR TITLE
feat: :sparkles: Added pagination utilities

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1,0 +1,2028 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_YESOREYERAM-INFINITY-DATASOURCE",
+      "label": "yesoreyeram-infinity-datasource",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "yesoreyeram-infinity-datasource",
+      "pluginName": "Infinity"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "barchart",
+      "name": "Bar chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.6.0"
+    },
+    {
+      "type": "panel",
+      "id": "marcusolsson-dynamictext-panel",
+      "name": "Business Text",
+      "version": "5.7.0"
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "yesoreyeram-infinity-datasource",
+      "name": "Infinity",
+      "version": "3.2.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Actual HTTP API",
+      "tooltip": "Open API docs",
+      "type": "link",
+      "url": "http://actualhttpapi:5007/api-docs/"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "panels": [
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "options": {
+            "afterRender": "",
+            "content": "<div class=\"alert alert-primary\" role=\"alert\">\n  You have selected: <b>{{name}}</b>\n</div>",
+            "contentPartials": [],
+            "defaultContent": "The query didn't return any results.",
+            "editor": {
+              "format": "auto",
+              "language": "html"
+            },
+            "editors": [
+              "helpers"
+            ],
+            "externalStyles": [],
+            "helpers": "import(\"https://esm.sh/bootstrap@5.0.2\");",
+            "renderMode": "everyRow",
+            "styles": "",
+            "wrap": true
+          },
+          "pluginVersion": "5.7.0",
+          "targets": [
+            {
+              "columns": [],
+              "filters": [],
+              "format": "table",
+              "global_query_id": "",
+              "parser": "uql",
+              "refId": "A",
+              "root_selector": "parse-json\n| project \"data\"",
+              "source": "url",
+              "type": "json",
+              "uql": "parse-json\r\n| project \"data\"",
+              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account",
+              "url_options": {
+                "data": "",
+                "method": "GET"
+              },
+              "datasource": {
+                "type": "yesoreyeram-infinity-datasource",
+                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+              }
+            }
+          ],
+          "title": "",
+          "transformations": [
+            {
+              "id": "extractFields",
+              "options": {
+                "delimiter": ",",
+                "format": "json",
+                "source": "result"
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "byVariable": false,
+                "include": {
+                  "names": [
+                    "name"
+                  ]
+                }
+              }
+            }
+          ],
+          "transparent": true,
+          "type": "marcusolsson-dynamictext-panel"
+        },
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto",
+                  "wrapText": false
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 13,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 4,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "columns": [],
+              "filters": [],
+              "format": "table",
+              "global_query_id": "",
+              "parser": "uql",
+              "refId": "A",
+              "root_selector": "parse-json\n| project \"data\"",
+              "source": "url",
+              "type": "json",
+              "uql": "parse-json\r\n| project \"data\"",
+              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts",
+              "url_options": {
+                "data": "",
+                "method": "GET"
+              },
+              "datasource": {
+                "type": "yesoreyeram-infinity-datasource",
+                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+              }
+            }
+          ],
+          "title": "Accounts List",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "id",
+                    "name",
+                    "offbudget"
+                  ]
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Accounts",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 6,
+      "panels": [
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "unit": "currencyEUR"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 16,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 8,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent",
+                "value"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "limit": 50,
+              "values": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "columns": [],
+              "datasource": {
+                "type": "yesoreyeram-infinity-datasource",
+                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+              },
+              "filters": [],
+              "format": "table",
+              "global_query_id": "",
+              "hide": false,
+              "parser": "uql",
+              "refId": "Categorie",
+              "root_selector": "",
+              "source": "url",
+              "type": "json",
+              "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"",
+              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categories",
+              "url_options": {
+                "data": "",
+                "method": "GET"
+              }
+            },
+            {
+              "columns": [],
+              "datasource": {
+                "type": "yesoreyeram-infinity-datasource",
+                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+              },
+              "filters": [],
+              "format": "dataframe",
+              "global_query_id": "",
+              "hide": false,
+              "parser": "uql",
+              "refId": "Transazioni",
+              "root_selector": "",
+              "source": "url",
+              "type": "json",
+              "uql": "parse-json\r\n| project \"data\"",
+              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+              "url_options": {
+                "data": "",
+                "method": "GET"
+              }
+            }
+          ],
+          "title": "",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "category",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "Categorie id"
+                  ],
+                  "reducer": "last"
+                }
+              }
+            },
+            {
+              "id": "filterByValue",
+              "options": {
+                "filters": [
+                  {
+                    "config": {
+                      "id": "regex",
+                      "options": {
+                        "value": "true"
+                      }
+                    },
+                    "fieldName": "Categorie is_income"
+                  }
+                ],
+                "match": "any",
+                "type": "exclude"
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "category",
+                "mode": "inner"
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "name Categorie",
+                    "amount Transazioni",
+                    "date Transazioni",
+                    "id Transazioni",
+                    "is_income Categorie"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "amount Transazioni": {
+                    "aggregations": [
+                      "sum"
+                    ],
+                    "operation": "aggregate"
+                  },
+                  "is_income Categorie": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "name Categorie": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  }
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "total_100",
+                "mode": "unary",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "unary": {
+                  "fieldName": "amount Transazioni (sum)",
+                  "operator": "abs"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "total",
+                "binary": {
+                  "left": {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "total_100"
+                    }
+                  },
+                  "operator": "/",
+                  "right": {
+                    "fixed": "100"
+                  }
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "name",
+                    "total"
+                  ]
+                }
+              }
+            }
+          ],
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "orange",
+                    "value": 50
+                  },
+                  {
+                    "color": "red",
+                    "value": 75
+                  }
+                ]
+              },
+              "unit": "currencyEUR"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 16,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 5,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "fullHighlight": false,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "orientation": "auto",
+            "showValue": "auto",
+            "stacking": "none",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            },
+            "xTickLabelRotation": 30,
+            "xTickLabelSpacing": 0
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "columns": [],
+              "datasource": {
+                "type": "yesoreyeram-infinity-datasource",
+                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+              },
+              "filters": [],
+              "format": "table",
+              "global_query_id": "",
+              "hide": false,
+              "parser": "uql",
+              "refId": "Categorie",
+              "root_selector": "",
+              "source": "url",
+              "type": "json",
+              "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"",
+              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categories",
+              "url_options": {
+                "data": "",
+                "method": "GET"
+              }
+            },
+            {
+              "columns": [],
+              "datasource": {
+                "type": "yesoreyeram-infinity-datasource",
+                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+              },
+              "filters": [],
+              "format": "dataframe",
+              "global_query_id": "",
+              "hide": false,
+              "parser": "uql",
+              "refId": "Transazioni",
+              "root_selector": "",
+              "source": "url",
+              "type": "json",
+              "uql": "parse-json\r\n| project \"data\"",
+              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+              "url_options": {
+                "data": "",
+                "method": "GET"
+              }
+            }
+          ],
+          "title": "",
+          "transformations": [
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "category",
+                "mode": "reduceRow",
+                "reduce": {
+                  "include": [
+                    "Categorie id"
+                  ],
+                  "reducer": "last"
+                }
+              }
+            },
+            {
+              "id": "filterByValue",
+              "options": {
+                "filters": [
+                  {
+                    "config": {
+                      "id": "regex",
+                      "options": {
+                        "value": "true"
+                      }
+                    },
+                    "fieldName": "Categorie is_income"
+                  }
+                ],
+                "match": "any",
+                "type": "exclude"
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "category",
+                "mode": "inner"
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "name Categorie",
+                    "amount Transazioni",
+                    "date Transazioni",
+                    "id Transazioni",
+                    "is_income Categorie"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "amount Transazioni": {
+                    "aggregations": [
+                      "sum"
+                    ],
+                    "operation": "aggregate"
+                  },
+                  "is_income Categorie": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "name Categorie": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  }
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "total_100",
+                "mode": "unary",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "unary": {
+                  "fieldName": "amount Transazioni (sum)",
+                  "operator": "abs"
+                }
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "total",
+                "binary": {
+                  "left": {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "total_100"
+                    }
+                  },
+                  "operator": "/",
+                  "right": {
+                    "fixed": "100"
+                  }
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                }
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "name",
+                    "total"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "total"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "barchart"
+        }
+      ],
+      "title": "Expenses by Category",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 11,
+      "panels": [
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "unit": "currencyEUR"
+            },
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": [
+                      "total (sum)",
+                      "Investments and Savings"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 16,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 9,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent",
+                "value"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/^total \\(sum\\)$/",
+              "limit": 50,
+              "values": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "columns": [],
+              "datasource": {
+                "type": "yesoreyeram-infinity-datasource",
+                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+              },
+              "filters": [],
+              "format": "table",
+              "global_query_id": "",
+              "hide": false,
+              "parser": "uql",
+              "refId": "Categorie",
+              "root_selector": "",
+              "source": "url",
+              "type": "json",
+              "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"\r\n| mv-expand \"categories\"",
+              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categorygroups",
+              "url_options": {
+                "data": "",
+                "method": "GET"
+              }
+            },
+            {
+              "columns": [],
+              "datasource": {
+                "type": "yesoreyeram-infinity-datasource",
+                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+              },
+              "filters": [],
+              "format": "dataframe",
+              "global_query_id": "",
+              "hide": false,
+              "parser": "uql",
+              "refId": "Transazioni",
+              "root_selector": "",
+              "source": "url",
+              "type": "json",
+              "uql": "parse-json\r\n| project \"data\"\r\n| project \"category\", \"amount\", \"date\"\r\n",
+              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+              "url_options": {
+                "data": "",
+                "method": "GET"
+              }
+            }
+          ],
+          "title": "",
+          "transformations": [
+            {
+              "id": "filterByValue",
+              "options": {
+                "filters": [
+                  {
+                    "config": {
+                      "id": "regex",
+                      "options": {
+                        "value": "true"
+                      }
+                    },
+                    "fieldName": "Categorie is_income"
+                  }
+                ],
+                "match": "any",
+                "type": "exclude"
+              }
+            },
+            {
+              "id": "extractFields",
+              "options": {
+                "delimiter": ",",
+                "format": "json",
+                "keepTime": false,
+                "replace": false,
+                "source": "categories"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "name 1",
+                "renamePattern": "group_name"
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "byVariable": false,
+                "include": {
+                  "names": [
+                    "Categorie id",
+                    "group_name",
+                    "Transazioni category",
+                    "Transazioni amount",
+                    "date"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "id 2",
+                "renamePattern": "category"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "id 1",
+                "renamePattern": "group_id"
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "category",
+                "mode": "inner"
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "total",
+                "binary": {
+                  "left": {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "amount Transazioni"
+                    }
+                  },
+                  "operator": "/",
+                  "right": {
+                    "fixed": "-100"
+                  }
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "replaceFields": false
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "group_name",
+                    "total"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "group_name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "total": {
+                    "aggregations": [
+                      "sum"
+                    ],
+                    "operation": "aggregate"
+                  }
+                }
+              }
+            }
+          ],
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 50
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyEUR"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 16,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 10,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "fullHighlight": false,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "orientation": "auto",
+            "showValue": "auto",
+            "stacking": "none",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            },
+            "xTickLabelRotation": 0,
+            "xTickLabelSpacing": 0
+          },
+          "pluginVersion": "11.6.0",
+          "targets": [
+            {
+              "columns": [],
+              "datasource": {
+                "type": "yesoreyeram-infinity-datasource",
+                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+              },
+              "filters": [],
+              "format": "table",
+              "global_query_id": "",
+              "hide": false,
+              "parser": "uql",
+              "refId": "Categorie",
+              "root_selector": "",
+              "source": "url",
+              "type": "json",
+              "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"\r\n| mv-expand \"categories\"",
+              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categorygroups",
+              "url_options": {
+                "data": "",
+                "method": "GET"
+              }
+            },
+            {
+              "columns": [],
+              "datasource": {
+                "type": "yesoreyeram-infinity-datasource",
+                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+              },
+              "filters": [],
+              "format": "dataframe",
+              "global_query_id": "",
+              "hide": false,
+              "parser": "uql",
+              "refId": "Transazioni",
+              "root_selector": "",
+              "source": "url",
+              "type": "json",
+              "uql": "parse-json\r\n| project \"data\"\r\n| project \"category\", \"amount\", \"date\"\r\n",
+              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+              "url_options": {
+                "data": "",
+                "method": "GET"
+              }
+            }
+          ],
+          "title": "",
+          "transformations": [
+            {
+              "id": "filterByValue",
+              "options": {
+                "filters": [
+                  {
+                    "config": {
+                      "id": "regex",
+                      "options": {
+                        "value": "true"
+                      }
+                    },
+                    "fieldName": "Categorie is_income"
+                  }
+                ],
+                "match": "any",
+                "type": "exclude"
+              }
+            },
+            {
+              "id": "extractFields",
+              "options": {
+                "delimiter": ",",
+                "format": "json",
+                "keepTime": false,
+                "replace": false,
+                "source": "categories"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "name 1",
+                "renamePattern": "group_name"
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "byVariable": false,
+                "include": {
+                  "names": [
+                    "Categorie id",
+                    "group_name",
+                    "Transazioni category",
+                    "Transazioni amount",
+                    "date"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "id 2",
+                "renamePattern": "category"
+              }
+            },
+            {
+              "id": "renameByRegex",
+              "options": {
+                "regex": "id 1",
+                "renamePattern": "group_id"
+              }
+            },
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "category",
+                "mode": "inner"
+              }
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "total",
+                "binary": {
+                  "left": {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "amount Transazioni"
+                    }
+                  },
+                  "operator": "/",
+                  "right": {
+                    "fixed": "-100"
+                  }
+                },
+                "mode": "binary",
+                "reduce": {
+                  "reducer": "sum"
+                },
+                "replaceFields": false
+              }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "group_name",
+                    "total"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "groupBy",
+              "options": {
+                "fields": {
+                  "group_name": {
+                    "aggregations": [],
+                    "operation": "groupby"
+                  },
+                  "total": {
+                    "aggregations": [
+                      "sum"
+                    ],
+                    "operation": "aggregate"
+                  }
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "total (sum)"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "barchart"
+        }
+      ],
+      "title": "Expenses by Category Group",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Expenses vs Income",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "unit": "currencyEUR"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Outcome"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": []
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Income"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 14,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "percent",
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "hide": false,
+          "parser": "uql",
+          "refId": "Categorie",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"\r\n| mv-expand \"categories\"",
+          "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categorygroups",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        },
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "filters": [],
+          "format": "dataframe",
+          "global_query_id": "",
+          "hide": false,
+          "parser": "uql",
+          "refId": "Transazioni",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "uql": "parse-json\r\n| project \"data\"\r\n| project \"category\", \"amount\", \"date\"\r\n",
+          "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "delimiter": ",",
+            "format": "json",
+            "keepTime": false,
+            "replace": false,
+            "source": "categories"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "name 1",
+            "renamePattern": "group_name"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "byVariable": false,
+            "include": {
+              "names": [
+                "Categorie id",
+                "group_name",
+                "Transazioni category",
+                "Transazioni amount",
+                "date",
+                "Categorie is_income"
+              ]
+            }
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "id 2",
+            "renamePattern": "category"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "id 1",
+            "renamePattern": "group_id"
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "category",
+            "mode": "inner"
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "total",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "amount Transazioni"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "-100"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total",
+            "mode": "unary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "unary": {
+              "fieldName": "total",
+              "operator": "abs"
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Total": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              },
+              "group_name": {
+                "aggregations": []
+              },
+              "is_income Categorie": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "total": {
+                "aggregations": [
+                  "sum"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "is_income 2": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Total (sum)": "Total",
+              "is_income 1": "Is Expenses",
+              "total (sum)": "Total"
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "string",
+                "targetField": "Is Expenses"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "Total",
+                "handlerKey": "field.value"
+              },
+              {
+                "fieldName": "Is Expenses",
+                "handlerKey": "field.name"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "false": "Outcome",
+              "true": "Income"
+            }
+          }
+        }
+      ],
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyEUR"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Outcome"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": []
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Income"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 16,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "hide": false,
+          "parser": "uql",
+          "refId": "Categorie",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"\r\n| mv-expand \"categories\"",
+          "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categorygroups",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        },
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "filters": [],
+          "format": "dataframe",
+          "global_query_id": "",
+          "hide": false,
+          "parser": "uql",
+          "refId": "Transazioni",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "uql": "parse-json\r\n| project \"data\"\r\n| project \"category\", \"amount\", \"date\"\r\n",
+          "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "delimiter": ",",
+            "format": "json",
+            "keepTime": false,
+            "replace": false,
+            "source": "categories"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "name 1",
+            "renamePattern": "group_name"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "byVariable": false,
+            "include": {
+              "names": [
+                "Categorie id",
+                "group_name",
+                "Transazioni category",
+                "Transazioni amount",
+                "date",
+                "Categorie is_income"
+              ]
+            }
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "id 2",
+            "renamePattern": "category"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "id 1",
+            "renamePattern": "group_id"
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "category",
+            "mode": "inner"
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "total",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "amount Transazioni"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "-100"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total",
+            "mode": "unary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "unary": {
+              "fieldName": "total",
+              "operator": "abs"
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Total": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              },
+              "group_name": {
+                "aggregations": []
+              },
+              "is_income Categorie": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "total": {
+                "aggregations": [
+                  "sum"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "is_income 2": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Total (sum)": "Total",
+              "is_income 1": "Is Expenses",
+              "total (sum)": "Total"
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "string",
+                "targetField": "Is Expenses"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "Total",
+                "handlerKey": "field.value"
+              },
+              {
+                "fieldName": "Is Expenses",
+                "handlerKey": "field.name"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "false": "Outcome",
+              "true": "Income"
+            }
+          }
+        }
+      ],
+      "type": "bargauge"
+    }
+  ],
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+        },
+        "definition": "",
+        "label": "Account ID",
+        "name": "account",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "columns": [],
+            "filters": [],
+            "format": "table",
+            "parser": "uql",
+            "refId": "variable",
+            "root_selector": "",
+            "source": "url",
+            "type": "json",
+            "uql": "parse-json\r\n| project \"data\"\r\n| project \"id\"",
+            "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts",
+            "url_options": {
+              "data": "",
+              "method": "GET"
+            }
+          },
+          "query": "",
+          "queryType": "infinity"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Improved Actual Budget",
+  "uid": "beim3ysg2yhogf",
+  "version": 75,
+  "weekStart": ""
+}

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -85,12 +85,12 @@
       "title": "Actual HTTP API",
       "tooltip": "Open API docs",
       "type": "link",
-      "url": "http://actualhttpapi:5007/api-docs/"
+      "url": "$instance/api-docs/"
     }
   ],
   "panels": [
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -98,192 +98,190 @@
         "y": 0
       },
       "id": 7,
-      "panels": [
-        {
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 24,
-            "x": 0,
-            "y": 1
-          },
-          "id": 2,
-          "options": {
-            "afterRender": "",
-            "content": "<div class=\"alert alert-primary\" role=\"alert\">\n  You have selected: <b>{{name}}</b>\n</div>",
-            "contentPartials": [],
-            "defaultContent": "The query didn't return any results.",
-            "editor": {
-              "format": "auto",
-              "language": "html"
-            },
-            "editors": [
-              "helpers"
-            ],
-            "externalStyles": [],
-            "helpers": "import(\"https://esm.sh/bootstrap@5.0.2\");",
-            "renderMode": "everyRow",
-            "styles": "",
-            "wrap": true
-          },
-          "pluginVersion": "5.7.0",
-          "targets": [
-            {
-              "columns": [],
-              "filters": [],
-              "format": "table",
-              "global_query_id": "",
-              "parser": "uql",
-              "refId": "A",
-              "root_selector": "parse-json\n| project \"data\"",
-              "source": "url",
-              "type": "json",
-              "uql": "parse-json\r\n| project \"data\"",
-              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account",
-              "url_options": {
-                "data": "",
-                "method": "GET"
-              },
-              "datasource": {
-                "type": "yesoreyeram-infinity-datasource",
-                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
-              }
-            }
-          ],
-          "title": "",
-          "transformations": [
-            {
-              "id": "extractFields",
-              "options": {
-                "delimiter": ",",
-                "format": "json",
-                "source": "result"
-              }
-            },
-            {
-              "id": "filterFieldsByName",
-              "options": {
-                "byVariable": false,
-                "include": {
-                  "names": [
-                    "name"
-                  ]
-                }
-              }
-            }
-          ],
-          "transparent": true,
-          "type": "marcusolsson-dynamictext-panel"
-        },
-        {
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "custom": {
-                "align": "auto",
-                "cellOptions": {
-                  "type": "auto",
-                  "wrapText": false
-                },
-                "inspect": false
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 13,
-            "w": 24,
-            "x": 0,
-            "y": 3
-          },
-          "id": 4,
-          "options": {
-            "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
-            "showHeader": true
-          },
-          "pluginVersion": "11.6.0",
-          "targets": [
-            {
-              "columns": [],
-              "filters": [],
-              "format": "table",
-              "global_query_id": "",
-              "parser": "uql",
-              "refId": "A",
-              "root_selector": "parse-json\n| project \"data\"",
-              "source": "url",
-              "type": "json",
-              "uql": "parse-json\r\n| project \"data\"",
-              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts",
-              "url_options": {
-                "data": "",
-                "method": "GET"
-              },
-              "datasource": {
-                "type": "yesoreyeram-infinity-datasource",
-                "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
-              }
-            }
-          ],
-          "title": "Accounts List",
-          "transformations": [
-            {
-              "id": "filterFieldsByName",
-              "options": {
-                "include": {
-                  "names": [
-                    "id",
-                    "name",
-                    "offbudget"
-                  ]
-                }
-              }
-            }
-          ],
-          "type": "table"
-        }
-      ],
+      "panels": [],
       "title": "Accounts",
       "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "afterRender": "",
+        "content": "<div class=\"alert alert-primary\" role=\"alert\">\n  You have selected: <b>{{name}}</b>\n</div>",
+        "contentPartials": [],
+        "defaultContent": "The query didn't return any results.",
+        "editor": {
+          "format": "auto",
+          "language": "html"
+        },
+        "editors": [
+          "helpers"
+        ],
+        "externalStyles": [],
+        "helpers": "import(\"https://esm.sh/bootstrap@5.0.2\");",
+        "renderMode": "everyRow",
+        "styles": "",
+        "wrap": true
+      },
+      "pluginVersion": "5.7.0",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "uql",
+          "refId": "A",
+          "root_selector": "parse-json\n| project \"data\"",
+          "source": "url",
+          "type": "json",
+          "uql": "parse-json\r\n| project \"data\"",
+          "url": "$instance/v1/budgets/$budget/accounts/$account",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "delimiter": ",",
+            "format": "json",
+            "source": "result"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "byVariable": false,
+            "include": {
+              "names": [
+                "name"
+              ]
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "marcusolsson-dynamictext-panel"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto",
+              "wrapText": false
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "uql",
+          "refId": "A",
+          "root_selector": "parse-json\n| project \"data\"",
+          "source": "url",
+          "type": "json",
+          "uql": "parse-json\r\n| project \"data\"",
+          "url": "$instance/v1/budgets/$budget/accounts",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Accounts List",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "id",
+                "name",
+                "offbudget"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "collapsed": true,
@@ -291,7 +289,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1
+        "y": 16
       },
       "id": 6,
       "panels": [
@@ -322,7 +320,7 @@
             "h": 16,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 32
           },
           "id": 8,
           "options": {
@@ -369,7 +367,7 @@
               "source": "url",
               "type": "json",
               "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"",
-              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categories",
+              "url": "$instance/v1/budgets/$budget/categories",
               "url_options": {
                 "data": "",
                 "method": "GET"
@@ -391,7 +389,7 @@
               "source": "url",
               "type": "json",
               "uql": "parse-json\r\n| project \"data\"",
-              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+              "url": "$instance/v1/budgets/$budget/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
               "url_options": {
                 "data": "",
                 "method": "GET"
@@ -584,7 +582,7 @@
             "h": 16,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 32
           },
           "id": 5,
           "options": {
@@ -627,7 +625,7 @@
               "source": "url",
               "type": "json",
               "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"",
-              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categories",
+              "url": "$instance/v1/budgets/$budget/categories",
               "url_options": {
                 "data": "",
                 "method": "GET"
@@ -649,7 +647,7 @@
               "source": "url",
               "type": "json",
               "uql": "parse-json\r\n| project \"data\"",
-              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+              "url": "$instance/v1/budgets/$budget/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
               "url_options": {
                 "data": "",
                 "method": "GET"
@@ -803,7 +801,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 2
+        "y": 17
       },
       "id": 11,
       "panels": [
@@ -860,7 +858,7 @@
             "h": 16,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 33
           },
           "id": 9,
           "options": {
@@ -907,7 +905,7 @@
               "source": "url",
               "type": "json",
               "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"\r\n| mv-expand \"categories\"",
-              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categorygroups",
+              "url": "$instance/v1/budgets/$budget/categorygroups",
               "url_options": {
                 "data": "",
                 "method": "GET"
@@ -929,7 +927,7 @@
               "source": "url",
               "type": "json",
               "uql": "parse-json\r\n| project \"data\"\r\n| project \"category\", \"amount\", \"date\"\r\n",
-              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+              "url": "$instance/v1/budgets/$budget/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
               "url_options": {
                 "data": "",
                 "method": "GET"
@@ -1120,7 +1118,7 @@
             "h": 16,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 33
           },
           "id": 10,
           "options": {
@@ -1163,7 +1161,7 @@
               "source": "url",
               "type": "json",
               "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"\r\n| mv-expand \"categories\"",
-              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categorygroups",
+              "url": "$instance/v1/budgets/$budget/categorygroups",
               "url_options": {
                 "data": "",
                 "method": "GET"
@@ -1185,7 +1183,7 @@
               "source": "url",
               "type": "json",
               "uql": "parse-json\r\n| project \"data\"\r\n| project \"category\", \"amount\", \"date\"\r\n",
-              "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+              "url": "$instance/v1/budgets/$budget/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
               "url_options": {
                 "data": "",
                 "method": "GET"
@@ -1341,7 +1339,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 18
       },
       "id": 12,
       "panels": [],
@@ -1410,7 +1408,7 @@
         "h": 16,
         "w": 12,
         "x": 0,
-        "y": 4
+        "y": 19
       },
       "id": 14,
       "options": {
@@ -1456,7 +1454,7 @@
           "source": "url",
           "type": "json",
           "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"\r\n| mv-expand \"categories\"",
-          "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categorygroups",
+          "url": "$instance/v1/budgets/$budget/categorygroups",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1478,7 +1476,7 @@
           "source": "url",
           "type": "json",
           "uql": "parse-json\r\n| project \"data\"\r\n| project \"category\", \"amount\", \"date\"\r\n",
-          "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+          "url": "$instance/v1/budgets/$budget/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1726,7 +1724,7 @@
         "h": 16,
         "w": 12,
         "x": 12,
-        "y": 4
+        "y": 19
       },
       "id": 16,
       "options": {
@@ -1771,7 +1769,7 @@
           "source": "url",
           "type": "json",
           "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"\r\n| mv-expand \"categories\"",
-          "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/categorygroups",
+          "url": "$instance/v1/budgets/$budget/categorygroups",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1793,7 +1791,7 @@
           "source": "url",
           "type": "json",
           "uql": "parse-json\r\n| project \"data\"\r\n| project \"category\", \"amount\", \"date\"\r\n",
-          "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+          "url": "$instance/v1/budgets/$budget/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1973,6 +1971,257 @@
         }
       ],
       "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyEUR"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Outcome"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": []
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Income"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 17,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "hide": false,
+          "parser": "uql",
+          "refId": "Categorie",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "uql": "parse-json\r\n| project \"data\"\r\n| project-away \"hidden\"\r\n| mv-expand \"categories\"",
+          "url": "$instance/v1/budgets/$budget/categorygroups",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        },
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "${DS_YESOREYERAM-INFINITY-DATASOURCE}"
+          },
+          "filters": [],
+          "format": "dataframe",
+          "global_query_id": "",
+          "hide": false,
+          "parser": "uql",
+          "refId": "Transazioni",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "uql": "parse-json\r\n| project \"data\"\r\n| project \"category\", \"amount\", \"date\", \"notes\"\r\n",
+          "url": "$instance/v1/budgets/$budget/accounts/$account/transactions?since_date=${__from:date:YYYY-MM-DD}&until_date=${__to:date:YYYY-MM-DD}",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "delimiter": ",",
+            "format": "json",
+            "keepTime": false,
+            "replace": false,
+            "source": "categories"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "name 1",
+            "renamePattern": "group_name"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "byVariable": false,
+            "include": {
+              "names": [
+                "Categorie id",
+                "group_name",
+                "Transazioni category",
+                "Transazioni amount",
+                "date",
+                "Transazioni notes",
+                "Categorie is_income"
+              ]
+            }
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "id 2",
+            "renamePattern": "category"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "is_income 1",
+            "renamePattern": "income"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "id 1",
+            "renamePattern": "group_id"
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "category",
+            "mode": "inner"
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "total",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "amount Transazioni"
+                }
+              },
+              "operator": "/",
+              "right": {
+                "fixed": "100"
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "amount Transazioni": true,
+              "category": true,
+              "group_id": true,
+              "is_income Categorie": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "amount Transazioni": 6,
+              "category": 1,
+              "date Transazioni": 0,
+              "group_id": 2,
+              "group_name": 4,
+              "is_income Categorie": 5,
+              "notes Transazioni": 7,
+              "total": 8
+            },
+            "renameByName": {
+              "amount Transazioni": "",
+              "is_income Categorie": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "schemaVersion": 41,
@@ -2000,7 +2249,7 @@
             "source": "url",
             "type": "json",
             "uql": "parse-json\r\n| project \"data\"\r\n| project \"id\"",
-            "url": "http://actualhttpapi:5007/v1/budgets/ac1be0a2-5b2f-41b5-9320-ee33375533f3/accounts",
+            "url": "$instance/v1/budgets/$budget/accounts",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -2012,6 +2261,40 @@
         "refresh": 1,
         "regex": "",
         "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "label": "Budget ID",
+        "name": "budget",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "label": "Instance Address",
+        "name": "instance",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "textbox"
       }
     ]
   },
@@ -2023,6 +2306,6 @@
   "timezone": "browser",
   "title": "Improved Actual Budget",
   "uid": "beim3ysg2yhogf",
-  "version": 75,
+  "version": 2,
   "weekStart": ""
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -39,8 +39,8 @@ exports.isEmpty = (obj) => {
 
 exports.listSubDirectories = (directory) => {
   return fs.readdirSync(directory, { withFileTypes: true })
-  .filter(dirent => dirent.isDirectory())
-  .map(dirent => dirent.name)
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => dirent.name)
 }
 
 exports.getFileContent = (filePath) => {
@@ -49,4 +49,33 @@ exports.getFileContent = (filePath) => {
 
 exports.parseNumericBoolean = (numericBoolean) => {
   return numericBoolean === 0 ? false : (numericBoolean === 1 ? true : numericBoolean);
+}
+
+exports.paginate = (array, page, limit) => {
+  const totalTransactions = array.length;
+  // Ensure the limit number is greater than 0
+  if (limit < 1) {
+    throw new Error(`Limit query parameter must be greater than 0`);
+  }
+  const numOfPages = Math.ceil(totalTransactions / limit);
+  // Ensure the page number is within bounds
+  if (page < 1 || page > numOfPages) {
+    throw new Error(`Page query parameter must be between 1 and ${numOfPages}. Changing limit parameter can also change the number of pages.`);
+  }
+  const selectedPage = Math.min(page, numOfPages);
+  // Calculate the total number of pages
+  const startIndex = (selectedPage - 1) * limit;
+  const endIndex = startIndex + limit;
+  // Slice the transactions for the current page
+  const paginatedTransactions = array.slice(startIndex, endIndex);
+  return paginatedTransactions
+}
+
+exports.validatePaginationParameters = (req) => {
+  if (!req.query.limit) {
+    throw new Error('limit query parameter is required when using pagination');
+  }
+  else if (!req.query.page) {
+    throw new Error('page query parameter is required when using pagination');
+  }
 }

--- a/src/v1/middlewares/error-handler.js
+++ b/src/v1/middlewares/error-handler.js
@@ -24,7 +24,9 @@ const errorHandler = (err, req, res, next) => {
     || err.message.includes('required')
     || err.message.includes('Bad date format')
     || err.message.includes('does not exist on table')
-    || err.message.includes('convert to integer')) {
+    || err.message.includes('convert to integer')
+    || err.message.includes('must be')
+  ) {
     clientError(res, 400, err, err.message);
   } else {
     serverError(res, err, 'Unknown error while interacting with Actual Api. See server logs for more information');

--- a/src/v1/routes/rules.js
+++ b/src/v1/routes/rules.js
@@ -1,3 +1,5 @@
+const { validatePaginationParameters, paginate } = require('../../utils/utils');
+
 /**
  * @swagger
  * tags:
@@ -12,6 +14,20 @@
  *         type: string
  *       required: true
  *       description: Rule id
+ *     page:
+ *       name: page
+ *       in: query
+ *       schema:
+ *         type: number
+ *       required: false
+ *       description: Page number. When limit is set, this parameter is required. Example 2
+ *     limit:
+ *       name: limit
+ *       in: query
+ *       schema:
+ *         type: number
+ *       required: false
+ *       description: Number of rules to return. When page is set, this parameter is required. Example 50
  *   schemas:
  *     ConditionOrAction:
  *       required:
@@ -70,6 +86,8 @@ module.exports = (router) => {
    *     parameters:
    *       - $ref: '#/components/parameters/budgetSyncId'
    *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *       - $ref: '#/components/parameters/page'
+   *       - $ref: '#/components/parameters/limit'
    *     responses:
    *       '200':
    *         description: The list of rules for the specified budget
@@ -191,8 +209,14 @@ module.exports = (router) => {
    */
   router.get('/budgets/:budgetSyncId/rules', async (req, res, next) => {
     try {
-      res.json({'data': await res.locals.budget.getRules()});
-    } catch(err) {
+      let allRules = await res.locals.budget.getRules();
+      if (req.query.page || req.query.limit) {
+        validatePaginationParameters(req);
+        res.json({ 'data': paginate(allRules, parseInt(req.query.page), parseInt(req.query.limit)) });
+      } else {
+        res.json({ 'data': allRules });
+      }
+    } catch (err) {
       next(err);
     }
   });


### PR DESCRIPTION
It is now possible to paginate the result of the transactions and rules getter queries. When one between "limit" and "page" parameter is set, the pagination is applied (both parameter must be set, otherwise it will throw an exception). If none of these parameters are set, the query will return all the entries. If the page is greater than the maximum number of pages (calculated using the limit parameter), it will throw an exception specifying the range of possible pages available.

No breaking changes since the new parameters are optional