### PR TITLE
 Add Schedule endpoints

### DIFF
--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -98,6 +98,12 @@ describe('Budget Module', () => {
       createRule: jest.fn().mockResolvedValue({ id: 'rule2' }),
       updateRule: jest.fn().mockResolvedValue({ id: 'rule1', description: 'Updated' }),
       deleteRule: jest.fn().mockResolvedValue(undefined),
+      getSchedules: jest.fn().mockResolvedValue([
+        { id: 'schedule1', name: 'Monthly Rent', amount: -150000 }
+      ]),
+      createSchedule: jest.fn().mockResolvedValue('schedule2'),
+      updateSchedule: jest.fn().mockResolvedValue({ id: 'schedule1', name: 'Updated Rent' }),
+      deleteSchedule: jest.fn().mockResolvedValue(undefined),
       getBudgets: jest.fn().mockResolvedValue([
         { id: 'budget1', groupId: 'sync1', name: 'Personal Budget' }
       ]),
@@ -588,6 +594,56 @@ describe('Budget Module', () => {
     it('should delete a rule', async () => {
       await budget.deleteRule('rule1');
       expect(mockActualApi.deleteRule).toHaveBeenCalledWith({ id: 'rule1' });
+    });
+  });
+
+  describe('Schedules Management', () => {
+    let budget;
+
+    beforeEach(async () => {
+      budget = await Budget('sync1', undefined);
+    });
+
+    it('should get all schedules', async () => {
+      const schedules = await budget.getSchedules();
+      expect(mockActualApi.getSchedules).toHaveBeenCalled();
+      expect(schedules).toHaveLength(1);
+      expect(schedules[0].id).toBe('schedule1');
+    });
+
+    it('should get a specific schedule', async () => {
+      const schedule = await budget.getSchedule('schedule1');
+      expect(schedule.id).toBe('schedule1');
+      expect(schedule.name).toBe('Monthly Rent');
+    });
+
+    it('should return undefined for non-existent schedule', async () => {
+      const schedule = await budget.getSchedule('nonexistent');
+      expect(schedule).toBeUndefined();
+    });
+
+    it('should create a new schedule', async () => {
+      const newSchedule = {
+        name: 'Weekly Groceries',
+        amount: -50000,
+        date: { frequency: 'weekly', start: '2024-01-01', endMode: 'never' }
+      };
+      const result = await budget.createSchedule(newSchedule);
+      expect(mockActualApi.createSchedule).toHaveBeenCalledWith(newSchedule);
+      expect(result).toBe('schedule2');
+    });
+
+    it('should update a schedule', async () => {
+      const updates = { name: 'Updated Monthly Rent', amount: -160000 };
+      const result = await budget.updateSchedule('schedule1', updates);
+      expect(mockActualApi.updateSchedule).toHaveBeenCalledWith('schedule1', updates);
+      expect(result.id).toBe('schedule1');
+      expect(result.name).toBe('Updated Rent');
+    });
+
+    it('should delete a schedule', async () => {
+      await budget.deleteSchedule('schedule1');
+      expect(mockActualApi.deleteSchedule).toHaveBeenCalledWith('schedule1');
     });
   });
 

--- a/__tests__/v1/routes/schedules.test.js
+++ b/__tests__/v1/routes/schedules.test.js
@@ -1,0 +1,327 @@
+// Ensure required secrets exist before importing modules that load config at module initialization
+process.env.API_KEY = process.env.API_KEY || 'test-api-key';
+process.env.ACTUAL_SERVER_PASSWORD = process.env.ACTUAL_SERVER_PASSWORD || 'test-password';
+
+describe('Schedules Routes', () => {
+  let mockRouter;
+  let mockBudget;
+  let mockReq;
+  let mockRes;
+  let mockNext;
+  let handlers;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    handlers = {};
+
+    mockRouter = {
+      get: jest.fn((path, handler) => {
+        handlers[`GET ${path}`] = handler;
+      }),
+      post: jest.fn((path, handler) => {
+        handlers[`POST ${path}`] = handler;
+      }),
+      patch: jest.fn((path, handler) => {
+        handlers[`PATCH ${path}`] = handler;
+      }),
+      delete: jest.fn((path, handler) => {
+        handlers[`DELETE ${path}`] = handler;
+      }),
+    };
+
+    mockBudget = {
+      getSchedules: jest.fn().mockResolvedValue([
+        {
+          id: 'schedule1',
+          name: 'Monthly Rent',
+          next_date: '2024-02-01',
+          completed: false,
+          posts_transaction: true,
+          amount: -150000,
+          amountOp: 'is',
+        },
+      ]),
+      getSchedule: jest.fn().mockResolvedValue({
+        id: 'schedule1',
+        name: 'Monthly Rent',
+        next_date: '2024-02-01',
+        completed: false,
+        posts_transaction: true,
+        amount: -150000,
+        amountOp: 'is',
+      }),
+      createSchedule: jest.fn().mockResolvedValue('new-schedule-id'),
+      updateSchedule: jest.fn().mockResolvedValue({
+        id: 'schedule1',
+        name: 'Updated Rent',
+        amount: -160000,
+      }),
+      deleteSchedule: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockReq = {
+      params: {},
+      query: {},
+      body: {},
+    };
+
+    mockRes = {
+      json: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+      locals: {
+        budget: mockBudget,
+      },
+    };
+
+    mockNext = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllTimers();
+  });
+
+  describe('GET /budgets/:budgetSyncId/schedules', () => {
+    it('should register the route', () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      expect(mockRouter.get).toHaveBeenCalledWith(
+        '/budgets/:budgetSyncId/schedules',
+        expect.any(Function)
+      );
+    });
+
+    it('should return list of schedules', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/schedules'];
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.getSchedules).toHaveBeenCalled();
+      expect(mockRes.json).toHaveBeenCalledWith({
+        data: expect.arrayContaining([
+          expect.objectContaining({ id: 'schedule1' }),
+        ]),
+      });
+    });
+
+    it('should support pagination', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/schedules'];
+      mockReq.query.page = '1';
+      mockReq.query.limit = '10';
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.getSchedules).toHaveBeenCalled();
+      expect(mockRes.json).toHaveBeenCalled();
+    });
+
+    it('should handle errors from getSchedules', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/schedules'];
+      const error = new Error('Failed to fetch schedules');
+      mockBudget.getSchedules.mockRejectedValueOnce(error);
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('GET /budgets/:budgetSyncId/schedules/:scheduleId', () => {
+    it('should register the route', () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      expect(mockRouter.get).toHaveBeenCalledWith(
+        '/budgets/:budgetSyncId/schedules/:scheduleId',
+        expect.any(Function)
+      );
+    });
+
+    it('should return specific schedule', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/schedules/:scheduleId'];
+      mockReq.params.scheduleId = 'schedule1';
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.getSchedule).toHaveBeenCalledWith('schedule1');
+      expect(mockRes.json).toHaveBeenCalledWith({
+        data: expect.objectContaining({ id: 'schedule1' }),
+      });
+    });
+
+    it('should handle not found schedule', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/schedules/:scheduleId'];
+      mockReq.params.scheduleId = 'nonexistent';
+      mockBudget.getSchedule.mockResolvedValueOnce(undefined);
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('POST /budgets/:budgetSyncId/schedules', () => {
+    it('should register the route', () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      expect(mockRouter.post).toHaveBeenCalledWith(
+        '/budgets/:budgetSyncId/schedules',
+        expect.any(Function)
+      );
+    });
+
+    it('should create a schedule', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/schedules'];
+      mockReq.body = {
+        schedule: {
+          name: 'New Schedule',
+          amount: -100000,
+          date: { frequency: 'monthly', start: '2024-01-01', endMode: 'never' },
+        },
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.createSchedule).toHaveBeenCalledWith(mockReq.body.schedule);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        data: 'new-schedule-id',
+      });
+    });
+
+    it('should reject without schedule property', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/schedules'];
+      mockReq.body = {};
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('PATCH /budgets/:budgetSyncId/schedules/:scheduleId', () => {
+    it('should register the route', () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      expect(mockRouter.patch).toHaveBeenCalledWith(
+        '/budgets/:budgetSyncId/schedules/:scheduleId',
+        expect.any(Function)
+      );
+    });
+
+    it('should update a schedule', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['PATCH /budgets/:budgetSyncId/schedules/:scheduleId'];
+      mockReq.params.scheduleId = 'schedule1';
+      mockReq.body = {
+        schedule: {
+          name: 'Updated Rent',
+          amount: -160000,
+        },
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.updateSchedule).toHaveBeenCalledWith('schedule1', mockReq.body.schedule);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        data: expect.objectContaining({ id: 'schedule1' }),
+      });
+    });
+
+    it('should reject without schedule property', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['PATCH /budgets/:budgetSyncId/schedules/:scheduleId'];
+      mockReq.params.scheduleId = 'schedule1';
+      mockReq.body = {};
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('should handle update errors', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['PATCH /budgets/:budgetSyncId/schedules/:scheduleId'];
+      mockReq.params.scheduleId = 'nonexistent';
+      mockReq.body = { schedule: { name: 'Updated' } };
+      const error = new Error('Schedule not found');
+      mockBudget.updateSchedule.mockRejectedValueOnce(error);
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('DELETE /budgets/:budgetSyncId/schedules/:scheduleId', () => {
+    it('should register the route', () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      expect(mockRouter.delete).toHaveBeenCalledWith(
+        '/budgets/:budgetSyncId/schedules/:scheduleId',
+        expect.any(Function)
+      );
+    });
+
+    it('should delete a schedule', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['DELETE /budgets/:budgetSyncId/schedules/:scheduleId'];
+      mockReq.params.scheduleId = 'schedule1';
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.deleteSchedule).toHaveBeenCalledWith('schedule1');
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Schedule deleted',
+      });
+    });
+
+    it('should handle delete errors', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['DELETE /budgets/:budgetSyncId/schedules/:scheduleId'];
+      mockReq.params.scheduleId = 'nonexistent';
+      const error = new Error('Schedule not found');
+      mockBudget.deleteSchedule.mockRejectedValueOnce(error);
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2161,7 +2160,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3179,7 +3177,6 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6801,7 +6798,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -8192,7 +8188,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
       "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -8859,7 +8854,6 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "peer": true,
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -253,6 +253,27 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     return actualApi.deleteRule({ id: ruleId });
   }
 
+  async function getSchedules() {
+    return actualApi.getSchedules();
+  }
+
+  async function getSchedule(scheduleId) {
+    const schedules = await getSchedules();
+    return schedules.find((schedule) => scheduleId == schedule.id);
+  }
+
+  async function createSchedule(schedule) {
+    return actualApi.createSchedule(schedule);
+  }
+
+  async function updateSchedule(scheduleId, schedule) {
+    return actualApi.updateSchedule(scheduleId, schedule);
+  }
+
+  async function deleteSchedule(scheduleId) {
+    return actualApi.deleteSchedule(scheduleId);
+  }
+
   async function getBudgets() {
     return actualApi.getBudgets();
   }
@@ -344,6 +365,11 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     createRule: createRule,
     updateRule: updateRule,
     deleteRule: deleteRule,
+    getSchedules: getSchedules,
+    getSchedule: getSchedule,
+    createSchedule: createSchedule,
+    updateSchedule: updateSchedule,
+    deleteSchedule: deleteSchedule,
     getBudgets: getBudgets,
     exportData: exportData,
     shutdown: shutdown,

--- a/src/v1/routes/index.js
+++ b/src/v1/routes/index.js
@@ -20,6 +20,7 @@ require('./transactions')(router);
 require('./categories')(router);
 require('./rules')(router);
 require('./payees')(router);
+require('./schedules')(router);
 require('./settings')(router);
 
 router.use(errorHandler);

--- a/src/v1/routes/schedules.js
+++ b/src/v1/routes/schedules.js
@@ -1,0 +1,409 @@
+const { validatePaginationParameters, paginate } = require('../../utils/utils');
+
+/**
+ * @swagger
+ * tags:
+ *   - name: Schedules
+ *     description: Endpoints for managing schedules. See [Schedules official documentation](https://actualbudget.org/docs/api/reference#schedule)
+ * components:
+ *   parameters:
+ *     scheduleId:
+ *       name: scheduleId
+ *       in: path
+ *       schema:
+ *         type: string
+ *       required: true
+ *       description: Schedule id
+ *   schemas:
+ *     RecurConfig:
+ *       type: object
+ *       required:
+ *         - frequency
+ *         - start
+ *         - endMode
+ *       properties:
+ *         frequency:
+ *           type: string
+ *           enum: ['daily', 'weekly', 'monthly', 'yearly']
+ *           description: Repetition frequency
+ *         interval:
+ *           type: number
+ *           description: Recurrence interval (default 1)
+ *         patterns:
+ *           type: array
+ *           items:
+ *             type: object
+ *           description: Specific recurrence patterns
+ *         skipWeekend:
+ *           type: boolean
+ *           description: Skip weekends when calculating dates
+ *         start:
+ *           type: string
+ *           format: date
+ *           description: ISO date string for recurrence start
+ *         endMode:
+ *           type: string
+ *           enum: ['never', 'after_n_occurrences', 'on_date']
+ *           description: Specifies recurrence termination
+ *         endOccurrences:
+ *           type: number
+ *           description: Count when endMode is after_n_occurrences
+ *         endDate:
+ *           type: string
+ *           format: date
+ *           description: ISO date when endMode is on_date
+ *         weekendSolveMode:
+ *           type: string
+ *           enum: ['before', 'after']
+ *           description: Adjusts dates falling on weekends
+ *     Schedule:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           description: UUID identifier
+ *         name:
+ *           type: string
+ *           description: Schedule name (must be unique)
+ *         rule:
+ *           type: string
+ *           description: Associated underlying rule (auto-created)
+ *         next_date:
+ *           type: string
+ *           format: date
+ *           description: Next occurrence date
+ *         completed:
+ *           type: boolean
+ *           description: Whether the schedule is completed
+ *         posts_transaction:
+ *           type: boolean
+ *           description: Auto-post transactions (default false)
+ *         payee:
+ *           type: string
+ *           nullable: true
+ *           description: Payee ID
+ *         account:
+ *           type: string
+ *           nullable: true
+ *           description: Account ID
+ *         amount:
+ *           oneOf:
+ *             - type: number
+ *             - type: object
+ *               properties:
+ *                 num1:
+ *                   type: number
+ *                 num2:
+ *                   type: number
+ *           description: Amount or range for isbetween
+ *         amountOp:
+ *           type: string
+ *           enum: ['is', 'isapprox', 'isbetween']
+ *           description: Controls amount interpretation
+ *         date:
+ *           oneOf:
+ *             - type: string
+ *               format: date
+ *             - $ref: '#/components/schemas/RecurConfig'
+ *           description: Single occurrence date or recurring pattern
+ *     ScheduleInput:
+ *       type: object
+ *       required:
+ *         - date
+ *       properties:
+ *         name:
+ *           type: string
+ *           description: Schedule name (must be unique)
+ *         posts_transaction:
+ *           type: boolean
+ *           description: Auto-post transactions (default false)
+ *         payee:
+ *           type: string
+ *           nullable: true
+ *           description: Payee ID
+ *         account:
+ *           type: string
+ *           nullable: true
+ *           description: Account ID
+ *         amount:
+ *           oneOf:
+ *             - type: number
+ *             - type: object
+ *               properties:
+ *                 num1:
+ *                   type: number
+ *                 num2:
+ *                   type: number
+ *           description: Amount or range for isbetween
+ *         amountOp:
+ *           type: string
+ *           enum: ['is', 'isapprox', 'isbetween']
+ *           description: Controls amount interpretation
+ *         date:
+ *           oneOf:
+ *             - type: string
+ *               format: date
+ *             - $ref: '#/components/schemas/RecurConfig'
+ *           description: Single occurrence date or recurring pattern
+ */
+
+module.exports = (router) => {
+  /**
+   * @swagger
+   * /budgets/{budgetSyncId}/schedules:
+   *   get:
+   *     summary: Returns list of schedules for the budget associated with the sync id specified
+   *     tags: [Schedules]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *       - $ref: '#/components/parameters/page'
+   *       - $ref: '#/components/parameters/limit'
+   *     responses:
+   *       '200':
+   *         description: The list of schedules for the specified budget
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: array
+   *                   items:
+   *                     $ref: '#/components/schemas/Schedule'
+   *               examples:
+   *                 - data:
+   *                   - id: '3ac44ad6-339a-459f-8eb6-fcff4cb87c34'
+   *                     name: 'Monthly Rent'
+   *                     next_date: '2024-02-01'
+   *                     completed: false
+   *                     posts_transaction: true
+   *                     amount: -150000
+   *                     amountOp: 'is'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   *   post:
+   *     summary: Creates a schedule
+   *     tags: [Schedules]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             required:
+   *               - schedule
+   *             type: object
+   *             properties:
+   *               schedule:
+   *                 $ref: '#/components/schemas/ScheduleInput'
+   *             examples:
+   *               - schedule:
+   *                   name: 'Monthly Rent'
+   *                   posts_transaction: true
+   *                   payee: '6740d5c1-5a89-4fa0-a35c-910e6da86e8r'
+   *                   account: '9787f2b1-d145-4afc-95b5-8f39ac68f8h5'
+   *                   amount: -150000
+   *                   amountOp: 'is'
+   *                   date:
+   *                     frequency: 'monthly'
+   *                     start: '2024-01-01'
+   *                     endMode: 'never'
+   *     responses:
+   *       '200':
+   *         description: Schedule created
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: string
+   *                   description: The ID of the created schedule
+   *               examples:
+   *                 - data: '3ac44ad6-339a-459f-8eb6-fcff4cb87c34'
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.get('/budgets/:budgetSyncId/schedules', async (req, res, next) => {
+    try {
+      let allSchedules = await res.locals.budget.getSchedules();
+      if (req.query.page || req.query.limit) {
+        validatePaginationParameters(req);
+        res.json({ 'data': paginate(allSchedules, parseInt(req.query.page), parseInt(req.query.limit)) });
+      } else {
+        res.json({ 'data': allSchedules });
+      }
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/budgets/:budgetSyncId/schedules', async (req, res, next) => {
+    try {
+      validateScheduleBody(req.body);
+      res.json({ 'data': await res.locals.budget.createSchedule(req.body.schedule) });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * @swagger
+   * /budgets/{budgetSyncId}/schedules/{scheduleId}:
+   *   get:
+   *     summary: Returns a schedule
+   *     tags: [Schedules]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/scheduleId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     responses:
+   *       '200':
+   *         description: Schedule
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   $ref: '#/components/schemas/Schedule'
+   *               examples:
+   *                 - data:
+   *                     id: '3ac44ad6-339a-459f-8eb6-fcff4cb87c34'
+   *                     name: 'Monthly Rent'
+   *                     next_date: '2024-02-01'
+   *                     completed: false
+   *                     posts_transaction: true
+   *                     amount: -150000
+   *                     amountOp: 'is'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   *   patch:
+   *     summary: Updates a schedule
+   *     tags: [Schedules]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/scheduleId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             required:
+   *               - schedule
+   *             type: object
+   *             properties:
+   *               schedule:
+   *                 $ref: '#/components/schemas/ScheduleInput'
+   *             examples:
+   *               - schedule:
+   *                   name: 'Updated Rent Payment'
+   *                   amount: -160000
+   *     responses:
+   *       '200':
+   *         description: Schedule updated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   $ref: '#/components/schemas/Schedule'
+   *               examples:
+   *                 - data:
+   *                     id: '3ac44ad6-339a-459f-8eb6-fcff4cb87c34'
+   *                     name: 'Updated Rent Payment'
+   *                     amount: -160000
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   *   delete:
+   *     summary: Deletes a schedule
+   *     tags: [Schedules]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/scheduleId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     responses:
+   *       '200':
+   *         description: Schedule deleted
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/GeneralResponseMessage'
+   *               examples:
+   *                 - message: Schedule deleted
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.get('/budgets/:budgetSyncId/schedules/:scheduleId', async (req, res, next) => {
+    try {
+      const schedule = await res.locals.budget.getSchedule(req.params.scheduleId);
+      if (!schedule) {
+        throw new Error(`Schedule with id '${req.params.scheduleId}' not found`);
+      }
+      res.json({ 'data': schedule });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.patch('/budgets/:budgetSyncId/schedules/:scheduleId', async (req, res, next) => {
+    try {
+      validateScheduleBody(req.body);
+      res.json({ 'data': await res.locals.budget.updateSchedule(req.params.scheduleId, req.body.schedule) });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.delete('/budgets/:budgetSyncId/schedules/:scheduleId', async (req, res, next) => {
+    try {
+      await res.locals.budget.deleteSchedule(req.params.scheduleId);
+      res.json({ 'message': 'Schedule deleted' });
+    } catch (err) {
+      next(err);
+    }
+  });
+};
+
+function validateScheduleBody(body) {
+  if (!body || !body.schedule) {
+    throw new Error('Schedule information is required');
+  }
+}


### PR DESCRIPTION
 ## Summary
  - Add HTTP endpoints for managing Actual Budget schedules
  - Implement CRUD operations: list, get, create, update, and delete schedules
  - Add comprehensive Swagger/OpenAPI documentation with Schedule and RecurConfig schemas
  - Add unit tests for all new endpoints and budget methods

  ## Endpoints Added
  | Method | Endpoint | Description |
  |--------|----------|-------------|
  | GET | `/budgets/{budgetSyncId}/schedules` | List all schedules (with pagination) |
  | GET | `/budgets/{budgetSyncId}/schedules/{scheduleId}` | Get schedule by ID |
  | POST | `/budgets/{budgetSyncId}/schedules` | Create new schedule |
  | PATCH | `/budgets/{budgetSyncId}/schedules/{scheduleId}` | Update schedule |
  | DELETE | `/budgets/{budgetSyncId}/schedules/{scheduleId}` | Delete schedule |
  
  ## Related Issue
  #49 