### PR TITLE
Added run-query route

### DIFF
--- a/__tests__/v1/routes/run-query.test.js
+++ b/__tests__/v1/routes/run-query.test.js
@@ -1,0 +1,237 @@
+// Ensure required secrets exist before importing modules that load config at module initialization
+process.env.API_KEY = process.env.API_KEY || 'test-api-key';
+process.env.ACTUAL_SERVER_PASSWORD = process.env.ACTUAL_SERVER_PASSWORD || 'test-password';
+
+describe('Run Query Routes', () => {
+  let mockRouter;
+  let mockBudget;
+  let mockReq;
+  let mockRes;
+  let mockNext;
+  let handlers;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    // Track all registered route handlers
+    handlers = {};
+
+    // Create a mock express router that tracks handlers
+    mockRouter = {
+      get: jest.fn((path, handler) => {
+        handlers[`GET ${path}`] = handler;
+      }),
+      post: jest.fn((path, handler) => {
+        handlers[`POST ${path}`] = handler;
+      }),
+      patch: jest.fn((path, handler) => {
+        handlers[`PATCH ${path}`] = handler;
+      }),
+      delete: jest.fn((path, handler) => {
+        handlers[`DELETE ${path}`] = handler;
+      }),
+      put: jest.fn((path, handler) => {
+        handlers[`PUT ${path}`] = handler;
+      }),
+    };
+
+    // Create a comprehensive mock budget object
+    const mockQuery = {
+      filter: jest.fn().mockReturnThis(),
+      unfilter: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      calculate: jest.fn().mockReturnThis(),
+      options: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      raw: jest.fn().mockReturnThis(),
+      withDead: jest.fn().mockReturnThis(),
+      withoutValidatedRefs: jest.fn().mockReturnThis(),
+    };
+
+    mockBudget = {
+      q: jest.fn().mockReturnValue(mockQuery),
+      runQuery: jest.fn().mockResolvedValue({ data: { some: 'data' } }),
+    };
+
+    // Create mock request/response objects
+    mockReq = {
+      params: {},
+      query: {},
+      body: {},
+    };
+
+    mockRes = {
+      json: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+      locals: {
+        budget: mockBudget,
+      },
+    };
+
+    mockNext = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllTimers();
+  });
+
+  describe('POST /budgets/:budgetSyncId/run-query', () => {
+    it('should register the route', () => {
+      const runQueryModule = require('../../../src/v1/routes/run-query');
+      runQueryModule(mockRouter);
+
+      expect(mockRouter.post).toHaveBeenCalledWith(
+        '/budgets/:budgetSyncId/run-query',
+        expect.any(Function)
+      );
+    });
+
+    it('should construct and run the query with multiple filters and flags', async () => {
+      const runQueryModule = require('../../../src/v1/routes/run-query');
+      runQueryModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/run-query'];
+      const queryParams = {
+        table: 'transactions',
+        filter: [
+          { date: { $gte: '2021-01-01' } },
+          { date: { $lte: '2021-12-31' } }
+        ],
+        select: ['*'],
+        raw: true
+      };
+      mockReq.body = {
+        ActualQLquery: queryParams
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.q).toHaveBeenCalledWith('transactions');
+      const mockQuery = mockBudget.q.mock.results[0].value;
+      expect(mockQuery.filter).toHaveBeenCalledTimes(2);
+      expect(mockQuery.filter).toHaveBeenNthCalledWith(1, { date: { $gte: '2021-01-01' } });
+      expect(mockQuery.filter).toHaveBeenNthCalledWith(2, { date: { $lte: '2021-12-31' } });
+      expect(mockQuery.select).toHaveBeenCalledWith(['*']);
+      expect(mockQuery.raw).toHaveBeenCalled();
+      expect(mockBudget.runQuery).toHaveBeenCalledWith(mockQuery);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        data: { some: 'data' },
+      });
+    });
+
+    it('should support withDead and withoutValidatedRefs flags', async () => {
+      const runQueryModule = require('../../../src/v1/routes/run-query');
+      runQueryModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/run-query'];
+      const queryParams = {
+        table: 'transactions',
+        withDead: true,
+        withoutValidatedRefs: true
+      };
+      mockReq.body = {
+        ActualQLquery: queryParams
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.q).toHaveBeenCalledWith('transactions');
+      const mockQuery = mockBudget.q.mock.results[0].value;
+      expect(mockQuery.withDead).toHaveBeenCalled();
+      expect(mockQuery.withoutValidatedRefs).toHaveBeenCalled();
+      expect(mockBudget.runQuery).toHaveBeenCalledWith(mockQuery);
+    });
+
+    it('should support calculate method', async () => {
+      const runQueryModule = require('../../../src/v1/routes/run-query');
+      runQueryModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/run-query'];
+      const queryParams = {
+        table: 'transactions',
+        calculate: { $sum: '$amount' }
+      };
+      mockReq.body = {
+        ActualQLquery: queryParams
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.q).toHaveBeenCalledWith('transactions');
+      const mockQuery = mockBudget.q.mock.results[0].value;
+      expect(mockQuery.calculate).toHaveBeenCalledWith({ $sum: '$amount' });
+      expect(mockBudget.runQuery).toHaveBeenCalledWith(mockQuery);
+    });
+
+    it('should support unfilter method', async () => {
+      const runQueryModule = require('../../../src/v1/routes/run-query');
+      runQueryModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/run-query'];
+      const queryParams = {
+        table: 'transactions',
+        unfilter: ['date']
+      };
+      mockReq.body = {
+        ActualQLquery: queryParams
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.q).toHaveBeenCalledWith('transactions');
+      const mockQuery = mockBudget.q.mock.results[0].value;
+      expect(mockQuery.unfilter).toHaveBeenCalledWith(['date']);
+      expect(mockBudget.runQuery).toHaveBeenCalledWith(mockQuery);
+    });
+
+    it('should throw error if ActualQLquery is missing', async () => {
+      const runQueryModule = require('../../../src/v1/routes/run-query');
+      runQueryModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/run-query'];
+      mockReq.body = {}; // Missing ActualQLquery
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNext.mock.calls[0][0].message).toBe('ActualQLquery is required in the request body');
+    });
+
+    it('should throw error if table is missing', async () => {
+      const runQueryModule = require('../../../src/v1/routes/run-query');
+      runQueryModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/run-query'];
+      mockReq.body = {
+        ActualQLquery: { filter: {} } // Missing table
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNext.mock.calls[0][0].message).toBe('table is required in ActualQLquery');
+    });
+
+    it('should handle errors from runQuery', async () => {
+      const runQueryModule = require('../../../src/v1/routes/run-query');
+      runQueryModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/run-query'];
+      mockReq.body = {
+        ActualQLquery: { table: 'transactions' }
+      };
+      const error = new Error('Query failed');
+      mockBudget.runQuery.mockRejectedValueOnce(error);
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+  });
+});

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -320,7 +320,12 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     };
   }
 
+  async function runQuery(query) {
+    return actualApi.runQuery(query);
+  }
+
   return {
+    q: actualApi.q,
     getMonths: getMonths,
     getMonth: getMonth,
     getMonthCategories: getMonthCategories,
@@ -372,6 +377,7 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     deleteSchedule: deleteSchedule,
     getBudgets: getBudgets,
     exportData: exportData,
+    runQuery: runQuery,
     shutdown: shutdown,
   };
 }

--- a/src/v1/routes/index.js
+++ b/src/v1/routes/index.js
@@ -22,6 +22,7 @@ require('./rules')(router);
 require('./payees')(router);
 require('./schedules')(router);
 require('./settings')(router);
+require('./run-query')(router);
 
 router.use(errorHandler);
 

--- a/src/v1/routes/run-query.js
+++ b/src/v1/routes/run-query.js
@@ -1,0 +1,146 @@
+/**
+ * @swagger
+ * tags:
+ *   - name: Query
+ *     description: Endpoints for running ActualQL queries.
+ * components:
+ *   schemas:
+ *     ActualQLquery:
+ *       type: object
+ *       required:
+ *         - table
+ *       properties:
+ *         table:
+ *           type: string
+ *           description: The table to query (e.g., 'transactions').
+ *         filter:
+ *           type: object
+ *           description: Filter criteria.
+ *         select:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: Fields to select.
+ *         options:
+ *           type: object
+ *           description: Query options.
+ *         groupBy:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: Fields to group by.
+ *         orderBy:
+ *           type: array
+ *           items:
+ *             type: object
+ *           description: Ordering criteria.
+ *         limit:
+ *           type: integer
+ *           description: Limit the number of results.
+ *         offset:
+ *           type: integer
+ *           description: Offset for results.
+ *         calculate:
+ *           type: object
+ *           description: Calculation expression.
+ *         unfilter:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: Array of filter keys to remove.
+ *         raw:
+ *           type: boolean
+ *           description: Return raw results.
+ *         withDead:
+ *           type: boolean
+ *           description: Include deleted items.
+ *         withoutValidatedRefs:
+ *           type: boolean
+ *           description: Disable reference validation.
+ */
+
+module.exports = (router) => {
+  /**
+   * @swagger
+   * /budgets/{budgetSyncId}/run-query:
+   *   post:
+   *     summary: Runs an arbitrary ActualQL query
+   *     tags: [Query]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             required:
+   *               - ActualQLquery
+   *             type: object
+   *             properties:
+   *               ActualQLquery:
+   *                 $ref: '#/components/schemas/ActualQLquery'
+   *     responses:
+   *       '200':
+   *         description: The result of the query
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: object
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.post('/budgets/:budgetSyncId/run-query', async (req, res, next) => {
+    try {
+      const queryParams = req.body.ActualQLquery;
+      if (!queryParams) {
+        throw new Error('ActualQLquery is required in the request body');
+      }
+      if (!queryParams.table) {
+        throw new Error('table is required in ActualQLquery');
+      }
+
+      let query = res.locals.budget.q(queryParams.table);
+
+      // These methods can be called multiple times to append expressions
+      ['filter', 'groupBy', 'orderBy'].forEach((method) => {
+        if (queryParams[method] !== undefined) {
+          const exprs = Array.isArray(queryParams[method])
+            ? queryParams[method]
+            : [queryParams[method]];
+          exprs.forEach((expr) => {
+            query = query[method](expr);
+          });
+        }
+      });
+
+      // These methods set a value (or accept an array as a single argument like unfilter)
+      ['select', 'calculate', 'options', 'limit', 'offset', 'unfilter'].forEach(
+        (method) => {
+          if (queryParams[method] !== undefined) {
+            query = query[method](queryParams[method]);
+          }
+        }
+      );
+
+      // Boolean flags
+      if (queryParams.raw === true) query = query.raw();
+      if (queryParams.withDead === true) query = query.withDead();
+      if (queryParams.withoutValidatedRefs === true)
+        query = query.withoutValidatedRefs();
+      const result = await res.locals.budget.runQuery(query);
+      res.json({ data: result.data });
+    } catch (err) {
+      next(err);
+    }
+  });
+};


### PR DESCRIPTION
Added a route to give access to the ActualQL queries through the API. 

From my testing it seems to work with the provided examples from https://actualbudget.org/docs/api/actual-ql/examples and https://actualbudget.org/docs/api/actual-ql/functions