### PR TITLE
feat: Add endpoints to set and delete notes

### DIFF
--- a/__tests__/v1/routes/notes.test.js
+++ b/__tests__/v1/routes/notes.test.js
@@ -19,12 +19,21 @@ describe('Notes Routes', () => {
       get: jest.fn((path, handler) => {
         handlers[`GET ${path}`] = handler;
       }),
+      put: jest.fn((path, handler) => {
+        handlers[`PUT ${path}`] = handler;
+      }),
+      delete: jest.fn((path, handler) => {
+        handlers[`DELETE ${path}`] = handler;
+      }),
     };
 
     mockBudget = {
       getCategoryNotes: jest.fn(),
+      setCategoryNotes: jest.fn(),
       getAccountNotes: jest.fn(),
+      setAccountNotes: jest.fn(),
       getBudgetMonthNotes: jest.fn(),
+      setBudgetMonthNotes: jest.fn(),
     };
 
     mockReq = {
@@ -159,6 +168,236 @@ describe('Notes Routes', () => {
 
       expect(mockRes.json).toHaveBeenCalledWith({
         data: ""
+      });
+    });
+
+  });
+
+  describe('PUT /budgets/:budgetSyncId/notes/category/:categoryId', () => {
+
+    it('should set category notes', async () => {
+      mockBudget.setCategoryNotes.mockResolvedValueOnce(undefined);
+
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['PUT /budgets/:budgetSyncId/notes/category/:categoryId'];
+
+      mockReq.params.categoryId = 'cat1';
+      mockReq.body = { data: 'New category note' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setCategoryNotes).toHaveBeenCalledWith('cat1', 'New category note');
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Category notes updated'
+      });
+    });
+
+    it('should accept an empty string', async () => {
+      mockBudget.setCategoryNotes.mockResolvedValueOnce(undefined);
+
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['PUT /budgets/:budgetSyncId/notes/category/:categoryId'];
+
+      mockReq.params.categoryId = 'cat1';
+      mockReq.body = { data: '' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setCategoryNotes).toHaveBeenCalledWith('cat1', '');
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Category notes updated'
+      });
+    });
+
+    it('should call next with an error when data is missing', async () => {
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['PUT /budgets/:budgetSyncId/notes/category/:categoryId'];
+
+      mockReq.params.categoryId = 'cat1';
+      mockReq.body = {};
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setCategoryNotes).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('should call next with an error when data is not a string', async () => {
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['PUT /budgets/:budgetSyncId/notes/category/:categoryId'];
+
+      mockReq.params.categoryId = 'cat1';
+      mockReq.body = { data: 123 };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setCategoryNotes).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+  });
+
+  describe('DELETE /budgets/:budgetSyncId/notes/category/:categoryId', () => {
+
+    it('should delete category notes by setting them to null', async () => {
+      mockBudget.setCategoryNotes.mockResolvedValueOnce(undefined);
+
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['DELETE /budgets/:budgetSyncId/notes/category/:categoryId'];
+
+      mockReq.params.categoryId = 'cat1';
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setCategoryNotes).toHaveBeenCalledWith('cat1', null);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Category notes deleted'
+      });
+    });
+
+    it('should call next with an error when the budget setter throws', async () => {
+      const error = new Error('boom');
+      mockBudget.setCategoryNotes.mockRejectedValueOnce(error);
+
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['DELETE /budgets/:budgetSyncId/notes/category/:categoryId'];
+
+      mockReq.params.categoryId = 'cat1';
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+
+  });
+
+  describe('PUT /budgets/:budgetSyncId/notes/account/:accountId', () => {
+
+    it('should set account notes', async () => {
+      mockBudget.setAccountNotes.mockResolvedValueOnce(undefined);
+
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['PUT /budgets/:budgetSyncId/notes/account/:accountId'];
+
+      mockReq.params.accountId = 'acc1';
+      mockReq.body = { data: 'New account note' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setAccountNotes).toHaveBeenCalledWith('acc1', 'New account note');
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Account notes updated'
+      });
+    });
+
+    it('should call next with an error when data is missing', async () => {
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['PUT /budgets/:budgetSyncId/notes/account/:accountId'];
+
+      mockReq.params.accountId = 'acc1';
+      mockReq.body = {};
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setAccountNotes).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+  });
+
+  describe('DELETE /budgets/:budgetSyncId/notes/account/:accountId', () => {
+
+    it('should delete account notes by setting them to null', async () => {
+      mockBudget.setAccountNotes.mockResolvedValueOnce(undefined);
+
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['DELETE /budgets/:budgetSyncId/notes/account/:accountId'];
+
+      mockReq.params.accountId = 'acc1';
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setAccountNotes).toHaveBeenCalledWith('acc1', null);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Account notes deleted'
+      });
+    });
+
+  });
+
+  describe('PUT /budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth', () => {
+
+    it('should set budget month notes', async () => {
+      mockBudget.setBudgetMonthNotes.mockResolvedValueOnce(undefined);
+
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['PUT /budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth'];
+
+      mockReq.params.budgetMonth = '2024-01';
+      mockReq.body = { data: 'Notes for January' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setBudgetMonthNotes).toHaveBeenCalledWith('2024-01', 'Notes for January');
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Budget month notes updated'
+      });
+    });
+
+    it('should call next with an error when data is missing', async () => {
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['PUT /budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth'];
+
+      mockReq.params.budgetMonth = '2024-01';
+      mockReq.body = {};
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setBudgetMonthNotes).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+  });
+
+  describe('DELETE /budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth', () => {
+
+    it('should delete budget month notes by setting them to null', async () => {
+      mockBudget.setBudgetMonthNotes.mockResolvedValueOnce(undefined);
+
+      const module = require('../../../src/v1/routes/notes');
+      module(mockRouter);
+
+      const handler = handlers['DELETE /budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth'];
+
+      mockReq.params.budgetMonth = '2024-01';
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.setBudgetMonthNotes).toHaveBeenCalledWith('2024-01', null);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Budget month notes deleted'
       });
     });
 

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -310,12 +310,20 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
         ).then(result => result?.data?.[0]?.note);
   }
 
+  async function setCategoryNotes(categoryId, note) {
+    return actualApi.internal.send('notes-save', { id: categoryId, note });
+  }
+
   async function getAccountNotes(accountId) {
     return runQuery(
           actualApi.q('notes')
             .filter({ id: `account-${accountId}`})
             .select(['note'])
         ).then(result => result?.data?.[0]?.note);
+  }
+
+  async function setAccountNotes(accountId, note) {
+    return actualApi.internal.send('notes-save', { id: `account-${accountId}`, note });
   }
 
   /**
@@ -327,6 +335,10 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
             .filter({ id: `budget-${month}`})
             .select(['note'])
         ).then(result => result?.data?.[0]?.note);
+  }
+
+  async function setBudgetMonthNotes(month, note) {
+    return actualApi.internal.send('notes-save', { id: `budget-${month}`, note });
   }
 
   async function shutdown() {
@@ -439,8 +451,11 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     updateTag: updateTag,
     deleteTag: deleteTag,
     getCategoryNotes: getCategoryNotes,
+    setCategoryNotes: setCategoryNotes,
     getAccountNotes: getAccountNotes,
+    setAccountNotes: setAccountNotes,
     getBudgetMonthNotes: getBudgetMonthNotes,
+    setBudgetMonthNotes: setBudgetMonthNotes,
     exportData: exportData,
     runQuery: runQuery,
     shutdown: shutdown,

--- a/src/v1/routes/notes.js
+++ b/src/v1/routes/notes.js
@@ -77,6 +77,7 @@ module.exports = (router) => {
    * /budgets/{budgetSyncId}/notes/category/{categoryId}:
    *   put:
    *     summary: Sets (creates or replaces) notes for a category
+   *     description: "⚠️ **Warning:** This endpoint interacts with the internals of Actual rather than the official API. It is not considered stable or secure for use and may change without notice."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -114,6 +115,7 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/500'
    *   delete:
    *     summary: Deletes notes for a category
+   *     description: "⚠️ **Warning:** This endpoint interacts with the internals of Actual rather than the official API. It is not considered stable or secure for use and may change without notice."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -202,6 +204,7 @@ module.exports = (router) => {
    * /budgets/{budgetSyncId}/notes/account/{accountId}:
    *   put:
    *     summary: Sets (creates or replaces) notes for an account
+   *     description: "⚠️ **Warning:** This endpoint interacts with the internals of Actual rather than the official API. It is not considered stable or secure for use and may change without notice."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -239,6 +242,7 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/500'
    *   delete:
    *     summary: Deletes notes for an account
+   *     description: "⚠️ **Warning:** This endpoint interacts with the internals of Actual rather than the official API. It is not considered stable or secure for use and may change without notice."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -327,6 +331,7 @@ module.exports = (router) => {
    * /budgets/{budgetSyncId}/notes/budgetmonth/{budgetMonth}:
    *   put:
    *     summary: Sets (creates or replaces) notes for a budget month
+   *     description: "⚠️ **Warning:** This endpoint interacts with the internals of Actual rather than the official API. It is not considered stable or secure for use and may change without notice."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -364,6 +369,7 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/500'
    *   delete:
    *     summary: Deletes notes for a budget month
+   *     description: "⚠️ **Warning:** This endpoint interacts with the internals of Actual rather than the official API. It is not considered stable or secure for use and may change without notice."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []

--- a/src/v1/routes/notes.js
+++ b/src/v1/routes/notes.js
@@ -2,7 +2,7 @@
  * @swagger
  * tags:
  *   - name: Notes
- *     description: Endpoints for retrieving notes
+ *     description: Endpoints for retrieving and modifying notes
  * components:
  *   parameters:
  *     categoryId:
@@ -74,6 +74,90 @@ module.exports = (router) => {
 
   /**
    * @swagger
+   * /budgets/{budgetSyncId}/notes/category/{categoryId}:
+   *   put:
+   *     summary: Sets (creates or replaces) notes for a category
+   *     tags: [Notes]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/categoryId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - data
+   *             properties:
+   *               data:
+   *                 type: string
+   *             examples:
+   *               - data: "This is a note for this category"
+   *     responses:
+   *       '200':
+   *         description: Category notes updated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/GeneralResponseMessage'
+   *               examples:
+   *                 - message: Category notes updated
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   *   delete:
+   *     summary: Deletes notes for a category
+   *     tags: [Notes]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/categoryId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     responses:
+   *       '200':
+   *         description: Category notes deleted
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/GeneralResponseMessage'
+   *               examples:
+   *                 - message: Category notes deleted
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.put('/budgets/:budgetSyncId/notes/category/:categoryId', async (req, res, next) => {
+    try {
+      if (typeof req.body?.data !== 'string') {
+        throw new Error('Request body must include a "data" string field');
+      }
+      await res.locals.budget.setCategoryNotes(req.params.categoryId, req.body.data);
+      res.json({ message: 'Category notes updated' });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.delete('/budgets/:budgetSyncId/notes/category/:categoryId', async (req, res, next) => {
+    try {
+      await res.locals.budget.setCategoryNotes(req.params.categoryId, null);
+      res.json({ message: 'Category notes deleted' });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * @swagger
    * /budgets/{budgetSyncId}/notes/account/{accountId}:
    *   get:
    *     summary: Returns notes for an account
@@ -115,6 +199,90 @@ module.exports = (router) => {
 
   /**
    * @swagger
+   * /budgets/{budgetSyncId}/notes/account/{accountId}:
+   *   put:
+   *     summary: Sets (creates or replaces) notes for an account
+   *     tags: [Notes]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/accountId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - data
+   *             properties:
+   *               data:
+   *                 type: string
+   *             examples:
+   *               - data: "Account notes"
+   *     responses:
+   *       '200':
+   *         description: Account notes updated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/GeneralResponseMessage'
+   *               examples:
+   *                 - message: Account notes updated
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   *   delete:
+   *     summary: Deletes notes for an account
+   *     tags: [Notes]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/accountId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     responses:
+   *       '200':
+   *         description: Account notes deleted
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/GeneralResponseMessage'
+   *               examples:
+   *                 - message: Account notes deleted
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.put('/budgets/:budgetSyncId/notes/account/:accountId', async (req, res, next) => {
+    try {
+      if (typeof req.body?.data !== 'string') {
+        throw new Error('Request body must include a "data" string field');
+      }
+      await res.locals.budget.setAccountNotes(req.params.accountId, req.body.data);
+      res.json({ message: 'Account notes updated' });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.delete('/budgets/:budgetSyncId/notes/account/:accountId', async (req, res, next) => {
+    try {
+      await res.locals.budget.setAccountNotes(req.params.accountId, null);
+      res.json({ message: 'Account notes deleted' });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * @swagger
    * /budgets/{budgetSyncId}/notes/budgetmonth/{budgetMonth}:
    *   get:
    *     summary: Returns notes for a budget month
@@ -149,6 +317,90 @@ module.exports = (router) => {
     try {
       const notes = await res.locals.budget.getBudgetMonthNotes(req.params.budgetMonth);
       res.json({ data: notes ?? "" });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * @swagger
+   * /budgets/{budgetSyncId}/notes/budgetmonth/{budgetMonth}:
+   *   put:
+   *     summary: Sets (creates or replaces) notes for a budget month
+   *     tags: [Notes]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/budgetMonth'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - data
+   *             properties:
+   *               data:
+   *                 type: string
+   *             examples:
+   *               - data: "Notes for March"
+   *     responses:
+   *       '200':
+   *         description: Budget month notes updated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/GeneralResponseMessage'
+   *               examples:
+   *                 - message: Budget month notes updated
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   *   delete:
+   *     summary: Deletes notes for a budget month
+   *     tags: [Notes]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/budgetMonth'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     responses:
+   *       '200':
+   *         description: Budget month notes deleted
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/GeneralResponseMessage'
+   *               examples:
+   *                 - message: Budget month notes deleted
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.put('/budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth', async (req, res, next) => {
+    try {
+      if (typeof req.body?.data !== 'string') {
+        throw new Error('Request body must include a "data" string field');
+      }
+      await res.locals.budget.setBudgetMonthNotes(req.params.budgetMonth, req.body.data);
+      res.json({ message: 'Budget month notes updated' });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.delete('/budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth', async (req, res, next) => {
+    try {
+      await res.locals.budget.setBudgetMonthNotes(req.params.budgetMonth, null);
+      res.json({ message: 'Budget month notes deleted' });
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## Motivation
While building out a native Mac client for Actual, I noticed that the Notes endpoints only included GET, with no way to create or modify. Without write access, I couldn't update my category templates. This PR addresses that gap.

## Summary
Adds `PUT` (set/replace) and `DELETE` (clear) endpoints for category, account, and budget month notes, complementing the existing `GET` endpoints so notes are fully CRUD.

- `PUT /budgets/:budgetSyncId/notes/category/:categoryId`
- `DELETE /budgets/:budgetSyncId/notes/category/:categoryId`
- `PUT /budgets/:budgetSyncId/notes/account/:accountId`
- `DELETE /budgets/:budgetSyncId/notes/account/:accountId`
- `PUT /budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth`
- `DELETE /budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth`

`PUT` accepts `{"data": "<note text>"}` matching the `GET` response shape and returns `{"message": "... updated"}`. `DELETE` is equivalent to `PUT` with `null` and returns `{"message": "... deleted"}`. Full swagger docs included for all six new endpoints.

ID scheme matches the existing getters:
- category → `categoryId`
- account → `account-${accountId}`
- budget month → `budget-${month}`

## Testing
- 12 new unit tests in `__tests__/v1/routes/notes.test.js` covering success paths, missing/non-string `data` validation, null-clear semantics, and error propagation.
- Full suite passes locally: 357/357 via `npm test --runInBand` and 5/5 consecutive parallel runs.
- **Live-tested end-to-end** against my own encrypted Actual: `GET → PUT → GET → DELETE → GET` sequence verified, and the note was confirmed visible in the Actual Web UI after `PUT` and absent after `DELETE`.