### PR TITLE
fix: [C1] replace forEach with for...of in deleteTransactions

### DIFF
--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -139,9 +139,9 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
 
   async function deleteTransactions(transactionIds = []) {
     return actualApi.batchBudgetUpdates(async () => {
-      transactionIds.forEach(async (transactionId) => {
+      for (const transactionId of transactionIds) {
         await actualApi.deleteTransaction(transactionId);
-      });
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

- Replaced forEach with for...of in deleteTransactions to ensure each deleteTransaction call is properly awaited inside batchBudgetUpdates
- forEach ignores the return value of async callbacks, meaning the batch could close before all deletes completed - silently leaving some transactions undeleted

## Test plan

- [x] All existing tests pass (npm test)
- [x] Manually tested batch delete of 6 transactions via DELETE /budgets/{budgetSyncId}/transactions/batch - all 6 confirmed deleted

Related to #87 [C1]