### PR TITLE
fix: [C2] replace internal note API usage with official getNote/updateNote

### DIFF
--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -113,6 +113,8 @@ describe('Budget Module', () => {
       createTag: jest.fn().mockResolvedValue({ id: 'tag2', tag: 'newtag' }),
       updateTag: jest.fn().mockResolvedValue({ id: 'tag1', tag: 'updated' }),
       deleteTag: jest.fn().mockResolvedValue(undefined),
+      getNote: jest.fn().mockResolvedValue({ id: 'cat1', note: 'Category note' }),
+      updateNote: jest.fn().mockResolvedValue(undefined),
       shutdown: jest.fn(),
       q: jest.fn(() => ({
         filter: jest.fn().mockReturnThis(),
@@ -773,46 +775,38 @@ describe('Budget Module', () => {
     });
 
     it('should get category notes', async () => {
-      mockActualApi.runQuery.mockResolvedValueOnce({
-        data: [{ note: 'Category note' }]
-      });
+      mockActualApi.getNote.mockResolvedValueOnce({ id: 'cat1', note: 'Category note' });
 
       const result = await budget.getCategoryNotes('cat1');
 
-      expect(mockActualApi.runQuery).toHaveBeenCalled();
+      expect(mockActualApi.getNote).toHaveBeenCalledWith('cat1');
       expect(result).toBe('Category note');
     });
 
     it('should get account notes', async () => {
-      mockActualApi.runQuery.mockResolvedValueOnce({
-        data: [{ note: 'Account note' }]
-      });
+      mockActualApi.getNote.mockResolvedValueOnce({ id: 'account-acc1', note: 'Account note' });
 
       const result = await budget.getAccountNotes('acc1');
 
-      expect(mockActualApi.runQuery).toHaveBeenCalled();
+      expect(mockActualApi.getNote).toHaveBeenCalledWith('account-acc1');
       expect(result).toBe('Account note');
     });
 
     it('should get budget month notes', async () => {
-      mockActualApi.runQuery.mockResolvedValueOnce({
-        data: [{ note: 'Month note' }]
-      });
+      mockActualApi.getNote.mockResolvedValueOnce({ id: 'budget-2024-01', note: 'Month note' });
 
       const result = await budget.getBudgetMonthNotes('2024-01');
 
-      expect(mockActualApi.runQuery).toHaveBeenCalled();
+      expect(mockActualApi.getNote).toHaveBeenCalledWith('budget-2024-01');
       expect(result).toBe('Month note');
     });
 
-    it('should return undefined when note not found', async () => {
-      mockActualApi.runQuery.mockResolvedValueOnce({
-        data: []
-      });
+    it('should return null when note not found', async () => {
+      mockActualApi.getNote.mockResolvedValueOnce(null);
 
       const result = await budget.getCategoryNotes('cat1');
 
-      expect(result).toBeUndefined();
+      expect(result).toBeNull();
     });
   });
 

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -310,42 +310,30 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
   }
 
   async function getCategoryNotes(categoryId) {
-    return runQuery(
-          actualApi.q('notes')
-            .filter({ id: categoryId})
-            .select(['note'])
-        ).then(result => result?.data?.[0]?.note);
+    const result = await actualApi.getNote(categoryId);
+    return result?.note ?? null;
   }
 
   async function setCategoryNotes(categoryId, note) {
-    return actualApi.internal.send('notes-save', { id: categoryId, note });
+    return actualApi.updateNote(categoryId, note);
   }
 
   async function getAccountNotes(accountId) {
-    return runQuery(
-          actualApi.q('notes')
-            .filter({ id: `account-${accountId}`})
-            .select(['note'])
-        ).then(result => result?.data?.[0]?.note);
+    const result = await actualApi.getNote(`account-${accountId}`);
+    return result?.note ?? null;
   }
 
   async function setAccountNotes(accountId, note) {
-    return actualApi.internal.send('notes-save', { id: `account-${accountId}`, note });
+    return actualApi.updateNote(`account-${accountId}`, note);
   }
 
-  /**
-   * @param {*} month - The month for which to get the notes, in format YYYY-MM
-   */
   async function getBudgetMonthNotes(month) {
-    return runQuery(
-          actualApi.q('notes')
-            .filter({ id: `budget-${month}`})
-            .select(['note'])
-        ).then(result => result?.data?.[0]?.note);
+    const result = await actualApi.getNote(`budget-${month}`);
+    return result?.note ?? null;
   }
 
   async function setBudgetMonthNotes(month, note) {
-    return actualApi.internal.send('notes-save', { id: `budget-${month}`, note });
+    return actualApi.updateNote(`budget-${month}`, note);
   }
 
   async function shutdown() {

--- a/src/v1/routes/notes.js
+++ b/src/v1/routes/notes.js
@@ -30,9 +30,6 @@
  */
 
 module.exports = (router) => {
-  const { config } = require('../../config/config');
-  const { EXPERIMENTAL_DISABLED_MESSAGE } = require('./constants');
-
   /**
    * @swagger
    * /budgets/{budgetSyncId}/notes/category/{categoryId}:
@@ -65,22 +62,9 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/404'
    *       '500':
    *         $ref: '#/components/responses/500'
-   */
-  router.get('/budgets/:budgetSyncId/notes/category/:categoryId', async (req, res, next) => {
-    try {
-      const notes = await res.locals.budget.getCategoryNotes(req.params.categoryId);
-      res.json({ data: notes ?? "" });
-    } catch (err) {
-      next(err);
-    }
-  });
-
-  /**
-   * @swagger
-   * /budgets/{budgetSyncId}/notes/category/{categoryId}:
    *   put:
-   *     summary: "(⚠️ Unofficial) Sets (creates or replaces) notes for a category"
-   *     description: "⚠️ Unofficial: Interacts with the internals of the official library APIs. It is not considered stable or secure for use and may change without notice."
+   *     summary: "(🔧 Extended) Sets (creates or replaces) notes for a category"
+   *     description: "🔧 Extended: Uses official library APIs with additional business logic or transformations."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -116,11 +100,9 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/404'
    *       '500':
    *         $ref: '#/components/responses/500'
-   *       '501':
-   *         $ref: '#/components/responses/501'
    *   delete:
-   *     summary: "(⚠️ Unofficial) Deletes notes for a category"
-   *     description: "⚠️ Unofficial: Interacts with the internals of the official library APIs. It is not considered stable or secure for use and may change without notice."
+   *     summary: "(🔧 Extended) Deletes notes for a category"
+   *     description: "🔧 Extended: Uses official library APIs with additional business logic or transformations."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -141,14 +123,18 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/404'
    *       '500':
    *         $ref: '#/components/responses/500'
-   *       '501':
-   *         $ref: '#/components/responses/501'
    */
+  router.get('/budgets/:budgetSyncId/notes/category/:categoryId', async (req, res, next) => {
+    try {
+      const notes = await res.locals.budget.getCategoryNotes(req.params.categoryId);
+      res.json({ data: notes ?? "" });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   router.put('/budgets/:budgetSyncId/notes/category/:categoryId', async (req, res, next) => {
     try {
-      if (!config.experimentalOperationsEnabled) {
-        return res.status(501).json({ error: EXPERIMENTAL_DISABLED_MESSAGE });
-      }
       if (typeof req.body?.data !== 'string') {
         throw new Error('Request body must include a "data" string field');
       }
@@ -161,9 +147,6 @@ module.exports = (router) => {
 
   router.delete('/budgets/:budgetSyncId/notes/category/:categoryId', async (req, res, next) => {
     try {
-      if (!config.experimentalOperationsEnabled) {
-        return res.status(501).json({ error: EXPERIMENTAL_DISABLED_MESSAGE });
-      }
       await res.locals.budget.setCategoryNotes(req.params.categoryId, null);
       res.json({ message: 'Category notes deleted' });
     } catch (err) {
@@ -203,22 +186,9 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/404'
    *       '500':
    *         $ref: '#/components/responses/500'
-   */
-  router.get('/budgets/:budgetSyncId/notes/account/:accountId', async (req, res, next) => {
-    try {
-      const notes = await res.locals.budget.getAccountNotes(req.params.accountId);
-      res.json({ data: notes ?? "" });
-    } catch (err) {
-      next(err);
-    }
-  });
-
-  /**
-   * @swagger
-   * /budgets/{budgetSyncId}/notes/account/{accountId}:
    *   put:
-   *     summary: "(⚠️ Unofficial) Sets (creates or replaces) notes for an account"
-   *     description: "⚠️ Unofficial: Interacts with the internals of the official library APIs. It is not considered stable or secure for use and may change without notice."
+   *     summary: "(🔧 Extended) Sets (creates or replaces) notes for an account"
+   *     description: "🔧 Extended: Uses official library APIs with additional business logic or transformations."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -254,11 +224,9 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/404'
    *       '500':
    *         $ref: '#/components/responses/500'
-   *       '501':
-   *         $ref: '#/components/responses/501'
    *   delete:
-   *     summary: "(⚠️ Unofficial) Deletes notes for an account"
-   *     description: "⚠️ Unofficial: Interacts with the internals of the official library APIs. It is not considered stable or secure for use and may change without notice."
+   *     summary: "(🔧 Extended) Deletes notes for an account"
+   *     description: "🔧 Extended: Uses official library APIs with additional business logic or transformations."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -279,14 +247,18 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/404'
    *       '500':
    *         $ref: '#/components/responses/500'
-   *       '501':
-   *         $ref: '#/components/responses/501'
    */
+  router.get('/budgets/:budgetSyncId/notes/account/:accountId', async (req, res, next) => {
+    try {
+      const notes = await res.locals.budget.getAccountNotes(req.params.accountId);
+      res.json({ data: notes ?? "" });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   router.put('/budgets/:budgetSyncId/notes/account/:accountId', async (req, res, next) => {
     try {
-      if (!config.experimentalOperationsEnabled) {
-        return res.status(501).json({ error: EXPERIMENTAL_DISABLED_MESSAGE });
-      }
       if (typeof req.body?.data !== 'string') {
         throw new Error('Request body must include a "data" string field');
       }
@@ -299,9 +271,6 @@ module.exports = (router) => {
 
   router.delete('/budgets/:budgetSyncId/notes/account/:accountId', async (req, res, next) => {
     try {
-      if (!config.experimentalOperationsEnabled) {
-        return res.status(501).json({ error: EXPERIMENTAL_DISABLED_MESSAGE });
-      }
       await res.locals.budget.setAccountNotes(req.params.accountId, null);
       res.json({ message: 'Account notes deleted' });
     } catch (err) {
@@ -341,22 +310,9 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/404'
    *       '500':
    *         $ref: '#/components/responses/500'
-   */
-  router.get('/budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth', async (req, res, next) => {
-    try {
-      const notes = await res.locals.budget.getBudgetMonthNotes(req.params.budgetMonth);
-      res.json({ data: notes ?? "" });
-    } catch (err) {
-      next(err);
-    }
-  });
-
-  /**
-   * @swagger
-   * /budgets/{budgetSyncId}/notes/budgetmonth/{budgetMonth}:
    *   put:
-   *     summary: "(⚠️ Unofficial) Sets (creates or replaces) notes for a budget month"
-   *     description: "⚠️ Unofficial: Interacts with the internals of the official library APIs. It is not considered stable or secure for use and may change without notice."
+   *     summary: "(🔧 Extended) Sets (creates or replaces) notes for a budget month"
+   *     description: "🔧 Extended: Uses official library APIs with additional business logic or transformations."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -392,11 +348,9 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/404'
    *       '500':
    *         $ref: '#/components/responses/500'
-   *       '501':
-   *         $ref: '#/components/responses/501'
    *   delete:
-   *     summary: "(⚠️ Unofficial) Deletes notes for a budget month"
-   *     description: "⚠️ Unofficial: Interacts with the internals of the official library APIs. It is not considered stable or secure for use and may change without notice."
+   *     summary: "(🔧 Extended) Deletes notes for a budget month"
+   *     description: "🔧 Extended: Uses official library APIs with additional business logic or transformations."
    *     tags: [Notes]
    *     security:
    *       - apiKey: []
@@ -417,14 +371,18 @@ module.exports = (router) => {
    *         $ref: '#/components/responses/404'
    *       '500':
    *         $ref: '#/components/responses/500'
-   *       '501':
-   *         $ref: '#/components/responses/501'
    */
+  router.get('/budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth', async (req, res, next) => {
+    try {
+      const notes = await res.locals.budget.getBudgetMonthNotes(req.params.budgetMonth);
+      res.json({ data: notes ?? "" });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   router.put('/budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth', async (req, res, next) => {
     try {
-      if (!config.experimentalOperationsEnabled) {
-        return res.status(501).json({ error: EXPERIMENTAL_DISABLED_MESSAGE });
-      }
       if (typeof req.body?.data !== 'string') {
         throw new Error('Request body must include a "data" string field');
       }
@@ -437,9 +395,6 @@ module.exports = (router) => {
 
   router.delete('/budgets/:budgetSyncId/notes/budgetmonth/:budgetMonth', async (req, res, next) => {
     try {
-      if (!config.experimentalOperationsEnabled) {
-        return res.status(501).json({ error: EXPERIMENTAL_DISABLED_MESSAGE });
-      }
       await res.locals.budget.setBudgetMonthNotes(req.params.budgetMonth, null);
       res.json({ message: 'Budget month notes deleted' });
     } catch (err) {


### PR DESCRIPTION
## Summary

Replaces all internal/unofficial note API usage with the official `getNote` and `updateNote` methods introduced in [actualbudget/actual#7769](https://github.com/actualbudget/actual/pull/7769).

Also removes the experimental flag gate from all note write routes, since they now use the official API surface.

## Files changed

**`src/v1/budget.js`**
The six note functions were using two unofficial approaches that are no longer needed:
- `getCategoryNotes`, `getAccountNotes`, `getBudgetMonthNotes` - were querying the internal `notes` table directly via `runQuery`, bypassing the public API
- `setCategoryNotes`, `setAccountNotes`, `setBudgetMonthNotes` - were calling `actualApi.internal.send('notes-save', ...)`, which is marked `@deprecated` in `@actual-app/api` v26.6.0

All six functions now use `actualApi.getNote(id)` and `actualApi.updateNote(id, note)`. The `.note` string is extracted from the returned `NoteEntity` to preserve the existing HTTP response shape.

**`src/v1/routes/notes.js`**
All six write routes (PUT/DELETE for categories, accounts, and budget months) were gated behind `experimentalOperationsEnabled`, returning `501` when the flag was off. Since the underlying implementation now uses the official API, the gate is no longer appropriate and has been removed. Swagger labels updated from `⚠️ Unofficial` to `🔧 Extended`.

**`__tests__/v1/budget.test.js`**
Updated the four notes tests to use the new `getNote` mock instead of `runQuery`. Added `getNote` and `updateNote` to the `mockActualApi` object. The "not found" test now asserts `null` (the value `getNote` returns when no note exists) rather than `undefined`.

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] Manually tested `GET`, `PUT`, and `DELETE` for all three note types (category, account, budget month) via Swagger UI
- [x] Confirmed `PUT` now returns `200` instead of `501` - the experimental gate is gone

Related to #87 [C2]
