### PR TITLE
fix: [C3] parse cutoff_date as local Date to avoid UTC timezone offset

### DIFF
--- a/__tests__/v1/routes/accounts.test.js
+++ b/__tests__/v1/routes/accounts.test.js
@@ -250,10 +250,25 @@ describe('Accounts Routes', () => {
 
       await handler(mockReq, mockRes, mockNext);
 
-      expect(mockBudget.getAccountBalance).toHaveBeenCalledWith('acc1', '2023-08-15');
+      expect(mockBudget.getAccountBalance).toHaveBeenCalledWith('acc1', new Date(2023, 7, 15));
       expect(mockRes.json).toHaveBeenCalledWith({
         data: 3500,
       });
+    });
+
+    it('should return 400 for invalid cutoff_date format', async () => {
+      const accountsModule = require('../../../src/v1/routes/accounts');
+      accountsModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/accounts/:accountId/balance'];
+      mockReq.params.accountId = 'acc1';
+      mockReq.query.cutoff_date = '15-08-2023';
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('Bad date format') })
+      );
     });
 
     it('should handle zero balance', async () => {

--- a/src/v1/routes/accounts.js
+++ b/src/v1/routes/accounts.js
@@ -21,7 +21,7 @@ const { isEmpty, formatDateToISOString } = require('../../utils/utils');
  *       schema:
  *         type: string
  *       required: false
- *       description: Account balance cutoff date. Example 2023-08-01
+ *       description: Account balance cutoff date in YYYY-MM-DD format. Example 2023-08-20
  *     sinceDate:
  *       name: since_date
  *       in: query
@@ -185,7 +185,15 @@ module.exports = (router) => {
    */                                                                                                                                                                                                                                       
   router.get('/budgets/:budgetSyncId/accounts/:accountId/balance', async (req, res, next) => {
     try {
-      const balance = await res.locals.budget.getAccountBalance(req.params.accountId, req.query.cutoff_date);                                                                                                                                                      
+      let cutoff;
+      if (req.query.cutoff_date) {
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(req.query.cutoff_date)) {
+          throw new Error(`Bad date format, use YYYY-MM-DD: ${req.query.cutoff_date}`);
+        }
+        const [year, month, day] = req.query.cutoff_date.split('-').map(Number);
+        cutoff = new Date(year, month - 1, day);
+      }
+      const balance = await res.locals.budget.getAccountBalance(req.params.accountId, cutoff);                                                                                                                                                      
       if (balance !== undefined) {           
         // Removing any additional field in the balance response                                                                                                                                                                                                             
         res.json({ data: balance || 0 });


### PR DESCRIPTION
## Summary

Fixes a timezone bug in the `getAccountBalance` route where a date string was passed directly to the upstream API instead of a `Date` object. Also adds input validation for the date format.

## Files changed

**`src/v1/routes/accounts.js`**
The route was passing `req.query.cutoff_date` (a plain string) directly to `actualApi.getAccountBalance`, which the `@actual-app/api` type definitions declare as `getAccountBalance(id: string, cutoff?: Date)`. Using `new Date('YYYY-MM-DD')` would parse the date as UTC midnight, which shifts it one day back in negative UTC offset timezones (e.g. UTC-5 would see `2026-01-02` as January 1st).

Fixed by parsing the date components manually - `new Date(year, month - 1, day)` - which creates a local midnight `Date` and avoids timezone offset issues entirely.

Also adds a `YYYY-MM-DD` format validation that returns `400` with a clear error message for invalid input, and updates the Swagger description to use an unambiguous example date (`2023-08-20` instead of `2023-08-01`, where the day value `20` makes the format self-evident).

**`__tests__/v1/routes/accounts.test.js`**
Updated the existing cutoff date assertion to expect `new Date(2023, 7, 15)` (local midnight) instead of the string `'2023-08-15'`. Added a new test verifying that an invalid format (`15-08-2023`) returns a `400`-triggering error.

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] Manually tested `GET /budgets/{budgetSyncId}/accounts/{accountId}/balance` with a valid cutoff date - returns correct balance
- [x] Manually tested with an invalid date format - returns `400` with `Bad date format, use YYYY-MM-DD`

Related to #87 [C3]
