### PR TITLE
fix: [C4] use URL ruleId as authoritative source in updateRule route

### DIFF
--- a/__tests__/v1/routes/rules.test.js
+++ b/__tests__/v1/routes/rules.test.js
@@ -236,7 +236,7 @@ describe('Rules Routes', () => {
       );
     });
 
-    it('should update a rule', async () => {
+    it('should update a rule using the URL ruleId when body has no id', async () => {
       const rulesModule = require('../../../src/v1/routes/rules');
       rulesModule(mockRouter);
 
@@ -255,10 +255,41 @@ describe('Rules Routes', () => {
 
       await handler(mockReq, mockRes, mockNext);
 
-      expect(mockBudget.updateRule).toHaveBeenCalledWith(mockReq.body.rule);
+      expect(mockBudget.updateRule).toHaveBeenCalledWith({ name: 'Updated Rule', id: 'rule1' });
       expect(mockRes.json).toHaveBeenCalledWith({
         data: expect.objectContaining({ id: 'rule1' }),
       });
+    });
+
+    it('should update a rule when body id matches URL ruleId', async () => {
+      const rulesModule = require('../../../src/v1/routes/rules');
+      rulesModule(mockRouter);
+
+      const handler = handlers['PATCH /budgets/:budgetSyncId/rules/:ruleId'];
+      mockReq.params.ruleId = 'rule1';
+      mockReq.body = { rule: { id: 'rule1', name: 'Updated Rule' } };
+
+      mockBudget.updateRule.mockResolvedValueOnce({ id: 'rule1', name: 'Updated Rule' });
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.updateRule).toHaveBeenCalledWith({ id: 'rule1', name: 'Updated Rule' });
+    });
+
+    it('should return 400 when body id differs from URL ruleId', async () => {
+      const rulesModule = require('../../../src/v1/routes/rules');
+      rulesModule(mockRouter);
+
+      const handler = handlers['PATCH /budgets/:budgetSyncId/rules/:ruleId'];
+      mockReq.params.ruleId = 'rule1';
+      mockReq.body = { rule: { id: 'rule2', name: 'Updated Rule' } };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('must be the same as the rule id in the URL parameter') })
+      );
+      expect(mockBudget.updateRule).not.toHaveBeenCalled();
     });
 
     it('should reject for nonexistent rule', async () => {

--- a/src/v1/routes/rules.js
+++ b/src/v1/routes/rules.js
@@ -379,7 +379,11 @@ module.exports = (router) => {
 
   router.patch('/budgets/:budgetSyncId/rules/:ruleId', async (req, res, next) => {
     try {
-      res.json({'data': await res.locals.budget.updateRule(req.body.rule)});
+      const bodyId = req.body.rule?.id;
+      if (bodyId && bodyId !== req.params.ruleId) {
+        throw new Error(`Rule id in request body must be the same as the rule id in the URL parameter`);
+      }
+      res.json({'data': await res.locals.budget.updateRule({ ...req.body.rule, id: req.params.ruleId })});
     } catch(err) {
       next(err);
     }


### PR DESCRIPTION
## Summary

Makes the URL `ruleId` path parameter the authoritative source of truth when updating a rule, and adds a mismatch check to prevent accidentally updating the wrong rule.

> ⚠️ **Potentially breaking** - see the breaking change note below.

## Background

The `@actual-app/api` docs [explicitly note](https://actualbudget.org/docs/api/reference) that `updateRule` is an exception among update methods: *"Unlike other update methods, this requires the full rule object including id."* Every other update method (`updateAccount`, `updateCategory`, `updatePayee`, etc.) takes `(id, fields)` as separate arguments, but `updateRule` takes the complete rule object including `id`.

Because of this, the existing `PATCH /rules/:ruleId` route was **ignoring `req.params.ruleId` entirely** - the rule `id` had to come from the request body. This is inconsistent with every other update endpoint in the HTTP API, which all use the URL path parameter as the resource identifier.

While the `@actual-app/api` design is intentional for the Node.js library, the HTTP wrapper should present a consistent REST interface regardless of the underlying library's conventions. The URL path parameter should always identify the resource being operated on.

## Files changed

**`src/v1/routes/rules.js`**
- Injects `req.params.ruleId` into the rule object before passing it to `updateRule`, consistent with how `updateTransaction` in `budget.js` already handles the same pattern (`{...transaction, id: transactionId}`)
- Adds a mismatch check: if the request body includes an `id` that differs from the URL `ruleId`, a `400` is returned immediately rather than silently overriding it - preventing the risk of unintentionally updating a different rule or having a non-existent URL ruleId bypass the body's real id

**`__tests__/v1/routes/rules.test.js`**
- Updated existing test to assert the URL ruleId is injected
- Added test for body id matching URL (proceeds normally)
- Added test for body id mismatching URL (returns 400)

## Behaviour after this change

| Scenario | Result |
|---|---|
| No `id` in body | URL `ruleId` injected, proceeds normally |
| Body `id` matches URL `ruleId` | Proceeds normally |
| Body `id` differs from URL `ruleId` | `400` - mismatch error |

## ⚠️ Breaking change

Existing integrations that relied on providing the real rule `id` in the request body while passing a different (or bogus) `id` in the URL path will now receive a `400` error. This was the only way to call the endpoint before this fix.

**Unaffected integrations:**
- Callers that omit `id` from the body (most common pattern after this fix)
- Callers that include `id` in the body matching the URL `ruleId`

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] Manually tested update with no `id` in body - succeeds using URL ruleId
- [x] Manually tested with matching body `id` - succeeds
- [x] Manually tested with mismatched body `id` - returns `400`

Related to #87 [C4]
