### PR TITLE
fix: [C5] fix export endpoint broken by archiver v8 ESM upgrade

### DIFF
--- a/__mocks__/archiver-shim.js
+++ b/__mocks__/archiver-shim.js
@@ -1,11 +1,11 @@
 const { EventEmitter } = require('events');
 
-function archiver(format, options) {
-  // Simple stream-like shim with chainable `file()` and `finalize()` methods
-  const stream = new EventEmitter();
-  stream.file = function () { return stream; };
-  stream.finalize = function () { return Promise.resolve(); };
-  return stream;
+class ZipArchive extends EventEmitter {
+  constructor(options) {
+    super();
+  }
+  file() { return this; }
+  finalize() { return Promise.resolve(); }
 }
 
-module.exports = archiver;
+module.exports = { ZipArchive };

--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -136,7 +136,7 @@ describe('Budget Module', () => {
       name: 'Personal Budget'
     }));
     getActualDataDir.mockReturnValue('/data/actual');
-    archiver.mockReturnValue(mockArchive);
+    archiver.ZipArchive.mockImplementation(() => mockArchive);
     path.join.mockImplementation((...args) => args.join('/'));
   });
 

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -382,18 +382,14 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     if (!budget) {
       throw new Error(`Budget not found for budget sync id ${budgetSyncId}`);
     }
-    // Create the archive. Prefer CommonJS `require` (works in Jest tests);
-    // fall back to dynamic ESM import when `require` is unavailable.
-    let archiver;
+    let ZipArchive;
     try {
-      // This will load our Jest-shimmed module during tests (or the CJS variant if available).
       // eslint-disable-next-line global-require
-      archiver = require('archiver');
+      ({ ZipArchive } = require('archiver'));
     } catch (err) {
-      const archiverModule = await import('archiver');
-      archiver = archiverModule && archiverModule.default ? archiverModule.default : archiverModule;
+      ({ ZipArchive } = await import('archiver'));
     }
-    const archive = archiver('zip', { zlib: { level: 9 } });
+    const archive = new ZipArchive({ zlib: { level: 9 } });
     // Add files to the archive
     for (const file of ['db.sqlite', 'metadata.json']) {
       archive.file(path.join(dataDir, budget.id, file), { name: file });


### PR DESCRIPTION
## Summary

Fixes the export endpoint which has been broken since PR #83 upgraded `archiver` from v7 to v8. The endpoint now throws `TypeError: archiver is not a function` at runtime.

## Root cause

`archiver` v8 is a pure ESM module. It no longer has a callable default export - only named exports (`ZipArchive`, `TarArchive`, `JsonArchive`). The previous implementation called `archiver('zip', ...)` after falling back to `import('archiver').default`, which is `undefined` in v8 since there is no default export.

## Files changed

**`src/v1/budget.js`**
Replaced the broken try/catch that called `archiver('zip', ...)` with the `ZipArchive` named export and `new ZipArchive(...)`, which is the correct v8 API. The require/import try-catch pattern is kept because Jest cannot intercept dynamic `import()` calls without `--experimental-vm-modules` - `require()` handles test environments where the shim is intercepted, and `import()` handles production where archiver v8 rejects `require()`.

**`__mocks__/archiver-shim.js`**
Updated to export `{ ZipArchive }` as a class matching the real archiver v8 named export shape, replacing the old callable function export that matched the v7 API.

**`__tests__/v1/budget.test.js`**
Updated mock setup from `archiver.mockReturnValue(mockArchive)` to `archiver.ZipArchive.mockImplementation(() => mockArchive)` to match the new named export shape.

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] Manually tested `GET /budgets/{budgetSyncId}/export` - zip file downloads correctly containing `db.sqlite` and `metadata.json`

Related to #87 [C5]
Fixes #99 
