### PR TITLE
fix: [P1] forward initialBalance in createAccount

### DIFF
--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -253,7 +253,14 @@ describe('Budget Module', () => {
     it('should create a new account', async () => {
       const newAccount = { name: 'Savings', type: 'savings' };
       const result = await budget.createAccount(newAccount);
-      expect(mockActualApi.createAccount).toHaveBeenCalledWith(newAccount);
+      expect(mockActualApi.createAccount).toHaveBeenCalledWith(newAccount, undefined);
+      expect(result.id).toBe('acc2');
+    });
+
+    it('should create a new account with initial balance', async () => {
+      const newAccount = { name: 'Savings', type: 'savings' };
+      const result = await budget.createAccount(newAccount, 10000);
+      expect(mockActualApi.createAccount).toHaveBeenCalledWith(newAccount, 10000);
       expect(result.id).toBe('acc2');
     });
 

--- a/__tests__/v1/routes/accounts.test.js
+++ b/__tests__/v1/routes/accounts.test.js
@@ -391,7 +391,7 @@ describe('Accounts Routes', () => {
       );
     });
 
-    it('should create an account', async () => {
+    it('should create an account without initialBalance', async () => {
       const accountsModule = require('../../../src/v1/routes/accounts');
       accountsModule(mockRouter);
 
@@ -405,16 +405,51 @@ describe('Accounts Routes', () => {
 
       await handler(mockReq, mockRes, mockNext);
 
-      expect(mockBudget.createAccount).toHaveBeenCalledWith({
-        name: 'New Account',
-        offbudget: false,
-      });
+      expect(mockBudget.createAccount).toHaveBeenCalledWith(
+        { name: 'New Account', offbudget: false },
+        undefined
+      );
       expect(mockRes.json).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          id: 'new-acc',
-          name: 'New Account',
-        }),
+        data: expect.objectContaining({ id: 'new-acc', name: 'New Account' }),
       });
+    });
+
+    it('should create an account with initialBalance', async () => {
+      const accountsModule = require('../../../src/v1/routes/accounts');
+      accountsModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/accounts'];
+      mockReq.body = {
+        account: {
+          name: 'New Account',
+          offbudget: false,
+          initialBalance: 10000,
+        },
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.createAccount).toHaveBeenCalledWith(
+        { name: 'New Account', offbudget: false },
+        10000
+      );
+    });
+
+    it('should return 400 for non-integer initialBalance', async () => {
+      const accountsModule = require('../../../src/v1/routes/accounts');
+      accountsModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/accounts'];
+      mockReq.body = {
+        account: { name: 'New Account', offbudget: false, initialBalance: 'abc' },
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('initialBalance must be an integer') })
+      );
+      expect(mockBudget.createAccount).not.toHaveBeenCalled();
     });
 
     it('should reject empty account info', async () => {

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -80,8 +80,8 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     return actualApi.getAccountBalance(accountId, cutoffDate);                                                       
   } 
 
-  async function createAccount(account) {
-    return actualApi.createAccount(account);
+  async function createAccount(account, initialBalance) {
+    return actualApi.createAccount(account, initialBalance);
   }
 
   async function updateAccount(accountId, account) {

--- a/src/v1/routes/accounts.js
+++ b/src/v1/routes/accounts.js
@@ -316,17 +316,20 @@ module.exports = (router) => {
    *               account:
    *                 required:
    *                   - name
-   *                   - offbudget
    *                 type: object
    *                 properties:
    *                   name:
    *                      type: string
    *                   offbudget:
    *                      type: boolean
+   *                   initialBalance:
+   *                      type: integer
+   *                      description: Optional initial balance in integer format (e.g. 10000 = $100.00)
    *             examples:
    *               - account:
    *                   name: 'Checking'
    *                   offbudget: false
+   *                   initialBalance: 10000
    *     responses:
    *       '200':
    *         description: Account created
@@ -346,7 +349,11 @@ module.exports = (router) => {
   router.post('/budgets/:budgetSyncId/accounts', async (req, res, next) => {
     try {
       validateAccountBody(req.body.account);
-      res.json({'data': await res.locals.budget.createAccount(req.body.account)});
+      const { initialBalance, ...account } = req.body.account;
+      if (initialBalance !== undefined && !Number.isInteger(initialBalance)) {
+        throw new Error('initialBalance must be an integer (e.g. 10000 = $100.00)');
+      }
+      res.json({'data': await res.locals.budget.createAccount(account, initialBalance)});
     } catch(err) {
       next(err);
     }


### PR DESCRIPTION
## Summary

Forwards the optional `initialBalance` parameter in `createAccount`, which was being silently discarded - all accounts were created with zero balance regardless of what was passed. Also adds validation to return a clear `400` for invalid values.

## Files changed

**`src/v1/budget.js`**
Updated `createAccount(account)` to `createAccount(account, initialBalance)` and passes it through to `actualApi.createAccount(account, initialBalance)`, matching the upstream signature `createAccount(account, initialBalance?: number)`.

**`src/v1/routes/accounts.js`**
- Destructures `initialBalance` from `req.body.account` (keeping it separate from the account fields before passing to the API)
- Adds validation: if `initialBalance` is provided it must be an integer - returns `400` with a clear message for invalid values such as strings, floats, or malformed JSON numbers. This prevents internal server errors from reaching the upstream API.
- Updates the Swagger `requestBody` annotation to document `initialBalance` as an optional integer field with an example

**`__tests__/v1/budget.test.js`**
Updated existing test and added a new test for creating an account with an explicit `initialBalance`.

**`__tests__/v1/routes/accounts.test.js`**
Updated existing test and added tests for: creating with `initialBalance`, and rejecting a non-integer `initialBalance` with `400`.

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] Manually tested account creation without `initialBalance` - balance is 0
- [x] Manually tested account creation with `initialBalance: 50000` - balance is $500.00
- [x] Manually tested with invalid `initialBalance` (string/malformed) - returns `400`

Related to #87 [P1]
