### PR TITLE
fix: [P2] forward hidden filter in getCategories and getCategoryGroups

### DIFF
--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -388,8 +388,19 @@ describe('Budget Module', () => {
 
     it('should get all categories', async () => {
       const categories = await budget.getCategories();
+      expect(mockActualApi.getCategories).toHaveBeenCalledWith({ hidden: undefined });
       expect(categories).toHaveLength(1);
       expect(categories[0].id).toBe('cat1');
+    });
+
+    it('should get hidden categories when hidden=true', async () => {
+      await budget.getCategories({ hidden: true });
+      expect(mockActualApi.getCategories).toHaveBeenCalledWith({ hidden: true });
+    });
+
+    it('should get visible categories when hidden=false', async () => {
+      await budget.getCategories({ hidden: false });
+      expect(mockActualApi.getCategories).toHaveBeenCalledWith({ hidden: false });
     });
 
     it('should get a specific category', async () => {
@@ -426,8 +437,14 @@ describe('Budget Module', () => {
 
     it('should get all category groups', async () => {
       const groups = await budget.getCategoryGroups();
+      expect(mockActualApi.getCategoryGroups).toHaveBeenCalledWith({ hidden: undefined });
       expect(groups).toHaveLength(1);
       expect(groups[0].id).toBe('cg1');
+    });
+
+    it('should get hidden category groups when hidden=true', async () => {
+      await budget.getCategoryGroups({ hidden: true });
+      expect(mockActualApi.getCategoryGroups).toHaveBeenCalledWith({ hidden: true });
     });
 
     it('should create a new category group', async () => {

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -145,8 +145,8 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     });
   }
 
-  async function getCategories() {
-    return actualApi.getCategories();
+  async function getCategories({ hidden } = {}) {
+    return actualApi.getCategories({ hidden });
   }
 
   async function getCategory(categoryId) {
@@ -166,8 +166,8 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     return actualApi.deleteCategory(categoryId, transferCategoryId);
   }
 
-  async function getCategoryGroups() {
-    return actualApi.getCategoryGroups();
+  async function getCategoryGroups({ hidden } = {}) {
+    return actualApi.getCategoryGroups({ hidden });
   }
 
   async function createCategoryGroup(categoryGroup) {

--- a/src/v1/routes/categories.js
+++ b/src/v1/routes/categories.js
@@ -70,6 +70,12 @@ module.exports = (router) => {
    *     parameters:
    *       - $ref: '#/components/parameters/budgetSyncId'
    *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *       - in: query
+   *         name: hidden
+   *         required: false
+   *         schema:
+   *           type: boolean
+   *         description: Filter by hidden status. Omit to return all categories.
    *     responses:
    *       '200':
    *         description: The list of categories
@@ -144,7 +150,10 @@ module.exports = (router) => {
    */
   router.get('/budgets/:budgetSyncId/categories', async (req, res, next) => {
     try {
-      res.json({'data': await res.locals.budget.getCategories()});
+      const hidden = req.query.hidden === 'true' ? true
+                   : req.query.hidden === 'false' ? false
+                   : undefined;
+      res.json({'data': await res.locals.budget.getCategories({ hidden })});
     } catch(err) {
       next(err);
     }
@@ -319,6 +328,12 @@ module.exports = (router) => {
    *     parameters:
    *       - $ref: '#/components/parameters/budgetSyncId'
    *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *       - in: query
+   *         name: hidden
+   *         required: false
+   *         schema:
+   *           type: boolean
+   *         description: Filter by hidden status. Omit to return all category groups.
    *     responses:
    *       '200':
    *         description: The list of category groups
@@ -397,7 +412,10 @@ module.exports = (router) => {
 
   router.get('/budgets/:budgetSyncId/categorygroups', async (req, res, next) => {
     try {
-      const categoryGroups = (await res.locals.budget.getCategoryGroups()) || [];
+      const hidden = req.query.hidden === 'true' ? true
+                   : req.query.hidden === 'false' ? false
+                   : undefined;
+      const categoryGroups = (await res.locals.budget.getCategoryGroups({ hidden })) || [];
       res.json({'data': categoryGroups.map(categoryGroup => {
         const categories = categoryGroup.categories || [];
         return {


### PR DESCRIPTION
## Summary

Forwards the optional `hidden` filter in `getCategories` and `getCategoryGroups`, which was being silently discarded. Callers can now pass `?hidden=true` to retrieve only hidden items, `?hidden=false` for only visible items, or omit the parameter to return all.

## Files changed

**`src/v1/budget.js`**
Updated `getCategories()` and `getCategoryGroups()` to accept `{ hidden }` as an optional parameter and pass it through to the upstream `@actual-app/api` methods, which both accept `options?: { hidden?: boolean }`.

**`src/v1/routes/categories.js`**
- Updated `GET /categories` and `GET /categorygroups` route handlers to parse `req.query.hidden` as a boolean (`'true'` - true, `'false'` - false, absent - undefined) and forward it to the budget wrapper
- Added a `?hidden` query parameter to the Swagger annotation for both routes

**`__tests__/v1/budget.test.js`**
Updated existing tests to assert the `{ hidden: undefined }` options object is passed through, and added new tests for `hidden=true` and `hidden=false` for both categories and category groups.

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] Manually tested `GET /categories` with no `hidden` param - returns all categories
- [x] Manually tested `GET /categories?hidden=true` - returns only hidden categories
- [x] Manually tested `GET /categories?hidden=false` - returns only visible categories
- [x] Repeated all three tests for `GET /categorygroups`

Related to #87 [P2]
