### PR TITLE
fix: [P3] forward resetNextDate in updateSchedule

### DIFF
--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -670,9 +670,15 @@ describe('Budget Module', () => {
     it('should update a schedule', async () => {
       const updates = { name: 'Updated Monthly Rent', amount: -160000 };
       const result = await budget.updateSchedule('schedule1', updates);
-      expect(mockActualApi.updateSchedule).toHaveBeenCalledWith('schedule1', updates);
+      expect(mockActualApi.updateSchedule).toHaveBeenCalledWith('schedule1', updates, undefined);
       expect(result.id).toBe('schedule1');
       expect(result.name).toBe('Updated Rent');
+    });
+
+    it('should update a schedule with resetNextDate', async () => {
+      const updates = { name: 'Updated Monthly Rent', amount: -160000 };
+      await budget.updateSchedule('schedule1', updates, true);
+      expect(mockActualApi.updateSchedule).toHaveBeenCalledWith('schedule1', updates, true);
     });
 
     it('should delete a schedule', async () => {

--- a/__tests__/v1/routes/schedules.test.js
+++ b/__tests__/v1/routes/schedules.test.js
@@ -234,25 +234,46 @@ describe('Schedules Routes', () => {
       );
     });
 
-    it('should update a schedule', async () => {
+    it('should update a schedule without resetNextDate', async () => {
       const schedulesModule = require('../../../src/v1/routes/schedules');
       schedulesModule(mockRouter);
 
       const handler = handlers['PATCH /budgets/:budgetSyncId/schedules/:scheduleId'];
       mockReq.params.scheduleId = 'schedule1';
       mockReq.body = {
-        schedule: {
-          name: 'Updated Rent',
-          amount: -160000,
-        },
+        schedule: { name: 'Updated Rent', amount: -160000 },
       };
 
       await handler(mockReq, mockRes, mockNext);
 
-      expect(mockBudget.updateSchedule).toHaveBeenCalledWith('schedule1', mockReq.body.schedule);
+      expect(mockBudget.updateSchedule).toHaveBeenCalledWith(
+        'schedule1',
+        { name: 'Updated Rent', amount: -160000 },
+        undefined
+      );
       expect(mockRes.json).toHaveBeenCalledWith({
         data: expect.objectContaining({ id: 'schedule1' }),
       });
+    });
+
+    it('should update a schedule with resetNextDate=true in body', async () => {
+      const schedulesModule = require('../../../src/v1/routes/schedules');
+      schedulesModule(mockRouter);
+
+      const handler = handlers['PATCH /budgets/:budgetSyncId/schedules/:scheduleId'];
+      mockReq.params.scheduleId = 'schedule1';
+      mockReq.body = {
+        schedule: { name: 'Updated Rent', amount: -160000 },
+        resetNextDate: true,
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.updateSchedule).toHaveBeenCalledWith(
+        'schedule1',
+        { name: 'Updated Rent', amount: -160000 },
+        true
+      );
     });
 
     it('should reject without schedule property', async () => {

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -277,8 +277,8 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     return actualApi.createSchedule(schedule);
   }
 
-  async function updateSchedule(scheduleId, schedule) {
-    return actualApi.updateSchedule(scheduleId, schedule);
+  async function updateSchedule(scheduleId, schedule, resetNextDate) {
+    return actualApi.updateSchedule(scheduleId, schedule, resetNextDate);
   }
 
   async function deleteSchedule(scheduleId) {

--- a/src/v1/routes/schedules.js
+++ b/src/v1/routes/schedules.js
@@ -322,10 +322,14 @@ module.exports = (router) => {
    *             properties:
    *               schedule:
    *                 $ref: '#/components/schemas/ScheduleInput'
+   *               resetNextDate:
+   *                 type: boolean
+   *                 description: When true, recalculates the next occurrence date
    *             examples:
    *               - schedule:
    *                   name: 'Updated Rent Payment'
    *                   amount: -160000
+   *                 resetNextDate: true
    *     responses:
    *       '200':
    *         description: Schedule updated
@@ -387,7 +391,7 @@ module.exports = (router) => {
   router.patch('/budgets/:budgetSyncId/schedules/:scheduleId', async (req, res, next) => {
     try {
       validateScheduleBody(req.body);
-      res.json({ 'data': await res.locals.budget.updateSchedule(req.params.scheduleId, req.body.schedule) });
+      res.json({ 'data': await res.locals.budget.updateSchedule(req.params.scheduleId, req.body.schedule, req.body.resetNextDate) });
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## Summary

Forwards the optional `resetNextDate` parameter in `updateSchedule`, which was never exposed through the HTTP route. When set to `true`, the upstream API recalculates the schedule's next occurrence date after the update.

This is additive and non-breaking - existing calls without `resetNextDate` behave exactly as before.

## Design decision

`resetNextDate` is a behaviour flag - it controls *how* the update is processed, not schedule data being saved. For that reason it is exposed as an optional top-level body property alongside `schedule`, consistent with the existing pattern used by `learnCategories` and `runTransfers` in the transactions endpoints:

```json
{ "schedule": { "name": "Updated Rent", "amount": -160000 }, "resetNextDate": true }
```

This keeps the body clean - `schedule` contains only schedule data, `resetNextDate` sits alongside it as a modifier.

## Files changed

**`src/v1/budget.js`**
Updated `updateSchedule(scheduleId, schedule)` to `updateSchedule(scheduleId, schedule, resetNextDate)` and passes it through to the upstream `actualApi.updateSchedule(id, fields, resetNextDate)`.

**`src/v1/routes/schedules.js`**
- Updated the `PATCH` route handler to read `req.body.resetNextDate` and pass it as the third argument to `budget.updateSchedule`
- Updated the Swagger `requestBody` annotation to document `resetNextDate` as an optional boolean top-level field alongside `schedule`

**`__tests__/v1/budget.test.js`**
Updated existing test to assert `undefined` is passed when `resetNextDate` is omitted, and added a new test for `resetNextDate: true`.

**`__tests__/v1/routes/schedules.test.js`**
Updated existing test and added a new test asserting `resetNextDate: true` from the body is correctly forwarded.

## Test plan

- [x] All existing tests pass (`npm test` - 361/361)
- [x] Manually tested `PATCH` without `resetNextDate` - schedule updates normally
- [x] Manually tested `PATCH` with `"resetNextDate": true` in body - next occurrence date recalculated

Related to #87 [P3]
