### PR TITLE
chore: [P5][D6] fix budget month Swagger schema accuracy

### DIFF
--- a/src/v1/routes/budget-months.js
+++ b/src/v1/routes/budget-months.js
@@ -60,15 +60,12 @@ const { isEmpty } = require('../../utils/utils');
  *         - name
  *         - is_income
  *         - categories
- *         - budgeted
- *         - spent
- *         - balance
  *       type: object
  *       properties:
  *         id:
  *           type: string
  *         name:
- *            type: integer
+ *            type: string
  *         is_income:
  *            type: boolean
  *         hidden:
@@ -79,26 +76,28 @@ const { isEmpty } = require('../../utils/utils');
  *             $ref: '#/components/schemas/BudgetMonthCategory'
  *         budgeted:
  *           type: integer
+ *           description: Present for expense groups and income groups in tracking budgets
  *         spent:
  *           type: integer
+ *           description: Present for expense groups only
  *         balance:
  *           type: integer
+ *           description: Present for expense groups and income groups in tracking budgets
+ *         received:
+ *           type: integer
+ *           description: Present for income groups only
  *     BudgetMonthCategory:
  *       required:
  *         - id
  *         - name
  *         - is_income
  *         - group_id
- *         - budgeted
- *         - spent
- *         - balance
- *         - carryover
  *       type: object
  *       properties:
  *         id:
  *           type: string
  *         name:
- *            type: integer
+ *            type: string
  *         is_income:
  *            type: boolean
  *         hidden:
@@ -107,12 +106,19 @@ const { isEmpty } = require('../../utils/utils');
  *           type: string
  *         budgeted:
  *           type: integer
+ *           description: Present for expense categories and income categories in tracking budgets
  *         spent:
  *           type: integer
+ *           description: Present for expense categories only
  *         balance:
  *           type: integer
+ *           description: Present for expense categories and income categories in tracking budgets
  *         carryover:
  *           type: boolean
+ *           description: Present for expense categories and income categories in tracking budgets
+ *         received:
+ *           type: integer
+ *           description: Present for income categories only
  */
 
 module.exports = (router) => {


### PR DESCRIPTION
## Summary

Fixes two Swagger schema bugs in `budget-months.js` ([D6]) and improves the accuracy of the category group and category schemas based on actual API responses from both envelope and tracking budgets ([P5]).

No code changes - documentation only.

## Files changed

**`src/v1/routes/budget-months.js`**

**[D6] - name field type fix**
Both `BudgetMonthCategoryGroup` and `BudgetMonthCategory` schemas had `name: type: integer`, which is wrong. Fixed to `type: string`.

**[P5] - schema accuracy based on verified real responses**

After testing against a real budget (both envelope and tracking types), the field structure differs by budget type and income vs. expense category:

| Field | Expense groups/categories | Income (envelope) | Income (tracking) |
|---|---|---|---|
| `budgeted` | yes | no | yes |
| `spent` | yes | no | no |
| `balance` | yes | no | yes |
| `carryover` | yes (category only) | no | yes |
| `received` | no | yes | yes |

Changes:
- `BudgetMonthCategoryGroup`: removed `carryover` (not present at group level in any budget type), added `received` as optional for income groups, relaxed `required` to only truly universal fields (`id`, `name`, `is_income`, `categories`), added descriptions clarifying which budget type each field appears in
- `BudgetMonthCategory`: added `received` as optional for income categories, relaxed `required` to core fields only, added matching descriptions
- `BudgetMonth` (top-level): no changes - `budgeted`/`received`/`balance`/`carryover` do not appear at the month level in either budget type

## Test plan

- [x] All existing tests pass (`npm test` - 359/359)
- [x] Verified response structure against a real envelope budget (`GET /months/2026-06`)
- [x] Verified response structure against a real tracking budget (`GET /months/2026-01`)

Related to #87 [P5] [D6]
