### PR TITLE
feat: [M1] expose getIDByName as GET /id-by-name endpoint

### DIFF
--- a/__tests__/v1/routes/utils.test.js
+++ b/__tests__/v1/routes/utils.test.js
@@ -1,0 +1,153 @@
+// Ensure required secrets exist before importing modules that load config at module initialization
+process.env.API_KEY = process.env.API_KEY || 'test-api-key';
+process.env.ACTUAL_SERVER_PASSWORD = process.env.ACTUAL_SERVER_PASSWORD || 'test-password';
+
+describe('Utils Routes', () => {
+  let mockRouter;
+  let mockBudget;
+  let mockReq;
+  let mockRes;
+  let mockNext;
+  let handlers;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    handlers = {};
+
+    mockRouter = {
+      get: jest.fn((path, handler) => {
+        handlers[`GET ${path}`] = handler;
+      }),
+    };
+
+    mockBudget = {
+      getIDByName: jest.fn().mockResolvedValue('671b669d-b616-4bf1-8a04-c82d73f87d5b'),
+    };
+
+    mockReq = {
+      params: {},
+      query: {},
+      body: {},
+    };
+
+    mockRes = {
+      json: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+      locals: { budget: mockBudget },
+    };
+
+    mockNext = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllTimers();
+  });
+
+  describe('GET /budgets/:budgetSyncId/id-by-name', () => {
+    it('should register the route', () => {
+      const utilsModule = require('../../../src/v1/routes/utils');
+      utilsModule(mockRouter);
+
+      expect(mockRouter.get).toHaveBeenCalledWith(
+        '/budgets/:budgetSyncId/id-by-name',
+        expect.any(Function)
+      );
+    });
+
+    it('should return the ID for a valid type and name', async () => {
+      const utilsModule = require('../../../src/v1/routes/utils');
+      utilsModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/id-by-name'];
+      mockReq.query = { type: 'accounts', name: 'Checking' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.getIDByName).toHaveBeenCalledWith('accounts', 'Checking');
+      expect(mockRes.json).toHaveBeenCalledWith({
+        data: '671b669d-b616-4bf1-8a04-c82d73f87d5b',
+      });
+    });
+
+    it('should return 400 when type is missing', async () => {
+      const utilsModule = require('../../../src/v1/routes/utils');
+      utilsModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/id-by-name'];
+      mockReq.query = { name: 'Checking' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('required') })
+      );
+      expect(mockBudget.getIDByName).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when name is missing', async () => {
+      const utilsModule = require('../../../src/v1/routes/utils');
+      utilsModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/id-by-name'];
+      mockReq.query = { type: 'accounts' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('required') })
+      );
+      expect(mockBudget.getIDByName).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for an invalid type', async () => {
+      const utilsModule = require('../../../src/v1/routes/utils');
+      utilsModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/id-by-name'];
+      mockReq.query = { type: 'transactions', name: 'something' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('"type" must be one of') })
+      );
+      expect(mockBudget.getIDByName).not.toHaveBeenCalled();
+    });
+
+    it('should propagate 404 when upstream throws not found', async () => {
+      const utilsModule = require('../../../src/v1/routes/utils');
+      utilsModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/id-by-name'];
+      mockReq.query = { type: 'accounts', name: 'Nonexistent' };
+      const upstreamError = new Error('Not found: accounts with name Nonexistent');
+      mockBudget.getIDByName.mockRejectedValueOnce(upstreamError);
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(upstreamError);
+    });
+
+    it('should work for all valid entity types', async () => {
+      const utilsModule = require('../../../src/v1/routes/utils');
+      utilsModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/id-by-name'];
+
+      for (const type of ['accounts', 'schedules', 'categories', 'payees']) {
+        jest.clearAllMocks();
+        mockReq.query = { type, name: 'Test' };
+        mockBudget.getIDByName.mockResolvedValueOnce('some-id');
+
+        await handler(mockReq, mockRes, mockNext);
+
+        expect(mockBudget.getIDByName).toHaveBeenCalledWith(type, 'Test');
+        expect(mockNext).not.toHaveBeenCalled();
+      }
+    });
+  });
+});

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -293,6 +293,10 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     return actualApi.getServerVersion();
   }
 
+  async function getIDByName(type, name) {
+    return actualApi.getIDByName(type, name);
+  }
+
   async function getTags() {
     return actualApi.getTags();
   }
@@ -463,6 +467,7 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     deleteSchedule: deleteSchedule,
     getBudgets: getBudgets,
     getServerVersion: getServerVersion,
+    getIDByName: getIDByName,
     getTags: getTags,
     createTag: createTag,
     updateTag: updateTag,

--- a/src/v1/middlewares/error-handler.js
+++ b/src/v1/middlewares/error-handler.js
@@ -17,6 +17,7 @@ const errorHandler = (err, req, res, next) => {
   } else if (err.message.includes('Could not get remote files')) {
     serverError(res, err, 'Error accessing Actual Server, check Actual Server password');
   } else if (err.message.includes('not found')
+    || err.message.includes('Not found')
     || err.message.includes('No budget')
     || err.message.includes('Cannot destructure property')) {
     clientError(res, 404, err, err.message);

--- a/src/v1/routes/index.js
+++ b/src/v1/routes/index.js
@@ -25,6 +25,7 @@ require('./settings')(router);
 require('./run-query')(router);
 require('./tags')(router);
 require('./notes')(router);
+require('./utils')(router);
 
 router.use(errorHandler);
 

--- a/src/v1/routes/utils.js
+++ b/src/v1/routes/utils.js
@@ -1,0 +1,77 @@
+/**
+ * @swagger
+ * tags:
+ *   - name: Utils
+ *     description: Utility endpoints
+ */
+
+module.exports = (router) => {
+  /**
+   * @swagger
+   * /budgets/{budgetSyncId}/id-by-name:
+   *   get:
+   *     summary: Get the ID of an entity by its name
+   *     tags: [Utils]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *       - in: query
+   *         name: type
+   *         required: true
+   *         schema:
+   *           type: string
+   *           enum: [accounts, schedules, categories, payees]
+   *         description: Entity type to look up
+   *       - in: query
+   *         name: name
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The name to look up
+   *     responses:
+   *       '200':
+   *         description: The ID of the matching entity
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: string
+   *                   description: Entity UUID
+   *               examples:
+   *                 - data: '671b669d-b616-4bf1-8a04-c82d73f87d5b'
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.get('/budgets/:budgetSyncId/id-by-name', async (req, res, next) => {
+    try {
+      const { type, name } = req.query;
+      if (!type || !name) {
+        throw Object.assign(
+          new Error('Query parameters "type" and "name" are required'),
+          { status: 400 }
+        );
+      }
+      const validTypes = ['accounts', 'schedules', 'categories', 'payees'];
+      if (!validTypes.includes(type)) {
+        throw Object.assign(
+          new Error(`"type" must be one of: ${validTypes.join(', ')}`),
+          { status: 400 }
+        );
+      }
+      const id = await res.locals.budget.getIDByName(type, name);
+      res.json({ data: id });
+    } catch (err) {
+      next(err);
+    }
+  });
+};


### PR DESCRIPTION
## Summary

Exposes the `getIDByName` upstream method as a new HTTP endpoint, allowing callers to resolve a human-readable name to its UUID for accounts, schedules, categories, and payees.

Also fixes the error handler to correctly return `404` for upstream `Not found` errors (capital N), which affected this and any future endpoint using the same upstream method.

## Files changed

**`src/v1/budget.js`**
Added `getIDByName(type, name)` wrapper delegating to `actualApi.getIDByName(type, name)` and exported it.

**`src/v1/routes/utils.js`** (new file)
New route `GET /budgets/:budgetSyncId/id-by-name?type=...&name=...` with:
- Validation that both `type` and `name` query params are provided (400 if missing)
- Validation that `type` is one of `accounts`, `schedules`, `categories`, `payees` (400 if invalid)
- Full Swagger annotation

**`src/v1/routes/index.js`**
Registered the new `utils` route module.

**`src/v1/middlewares/error-handler.js`**
Added `'Not found'` (capital N) to the 404 pattern list. The upstream `@actual-app/api` throws errors with `'Not found: ...'` (capital N) for missing entities, but the handler only checked lowercase `'not found'`, causing these to fall through to a 500.

**`__tests__/v1/routes/utils.test.js`** (new file)
7 tests covering: happy path for all 4 valid types, missing `type`, missing `name`, invalid `type`, and upstream not-found error propagation.

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] `GET /id-by-name?type=accounts&name=Checking%20Account` returns the correct UUID
- [x] `GET /id-by-name?type=accounts&name=NonExistent` returns `404`
- [x] `GET /id-by-name?type=transactions&name=test` returns `400`
- [x] `GET /id-by-name?type=accounts` (no name) returns `400`

Related to #87 [M1]
