### PR TITLE
Fix encrypted budget reopen handling

### DIFF
--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -140,20 +140,65 @@ describe('Budget Module', () => {
     }));
     getActualDataDir.mockReturnValue('/data/actual');
     archiver.ZipArchive.mockImplementation(() => mockArchive);
+    fs.existsSync.mockReturnValue(true);
     path.join.mockImplementation((...args) => args.join('/'));
   });
 
   describe('Budget Initialization', () => {
     it('should download budget when syncId is not cached', async () => {
-      const budget = await Budget('sync-new', undefined);
+      await Budget('sync-new', undefined);
       expect(mockActualApi.downloadBudget).toHaveBeenCalledWith('sync-new');
     });
 
     it('should download budget with password when provided', async () => {
-      const budget = await Budget('sync-pwd', 'password123');
+      await Budget('sync-pwd', 'password123');
       expect(mockActualApi.downloadBudget).toHaveBeenCalledWith('sync-pwd', {
         password: 'password123'
       });
+    });
+
+    it('should load and sync cached budgets when no password is provided', async () => {
+      getFileContent.mockReturnValueOnce(JSON.stringify({
+        id: 'budget-cached-plain',
+        groupId: 'sync-cached-plain',
+        name: 'Cached Plain Budget'
+      }));
+
+      await Budget('sync-cached-plain');
+
+      jest.clearAllMocks();
+      getActualApiClient.mockResolvedValue(mockActualApi);
+
+      await Budget('sync-cached-plain');
+
+      expect(mockActualApi.loadBudget).toHaveBeenCalledWith('budget-cached-plain');
+      expect(mockActualApi.sync).toHaveBeenCalledTimes(1);
+      expect(mockActualApi.downloadBudget).not.toHaveBeenCalled();
+      expect(listSubDirectories).not.toHaveBeenCalled();
+      expect(getFileContent).not.toHaveBeenCalled();
+    });
+
+    it('should download cached budgets with password instead of loading and syncing', async () => {
+      getFileContent.mockReturnValueOnce(JSON.stringify({
+        id: 'budget-cached-encrypted',
+        groupId: 'sync-cached-encrypted',
+        name: 'Cached Encrypted Budget'
+      }));
+
+      await Budget('sync-cached-encrypted', 'first-password');
+
+      jest.clearAllMocks();
+      getActualApiClient.mockResolvedValue(mockActualApi);
+
+      await Budget('sync-cached-encrypted', 'reopen-password');
+
+      expect(mockActualApi.downloadBudget).toHaveBeenCalledWith('sync-cached-encrypted', {
+        password: 'reopen-password'
+      });
+      expect(mockActualApi.loadBudget).not.toHaveBeenCalled();
+      expect(mockActualApi.sync).not.toHaveBeenCalled();
+      expect(listSubDirectories).not.toHaveBeenCalled();
+      expect(getFileContent).not.toHaveBeenCalled();
     });
   });
 

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -10,8 +10,14 @@ let syncIdToBudgetId = {};
 async function Budget(budgetSyncId, budgetEncryptionPassword) {
   const actualApi = await getActualApiClient();
   if (budgetSyncId in syncIdToBudgetId) {
-    await actualApi.loadBudget(syncIdToBudgetId[budgetSyncId]);
-    await actualApi.sync();
+    if (budgetEncryptionPassword) {
+      await actualApi.downloadBudget(budgetSyncId, {
+        password: budgetEncryptionPassword
+      });
+    } else {
+      await actualApi.loadBudget(syncIdToBudgetId[budgetSyncId]);
+      await actualApi.sync();
+    }
   } else {
     if (budgetEncryptionPassword) {
       await actualApi.downloadBudget(budgetSyncId, {

--- a/src/v1/routes/index.js
+++ b/src/v1/routes/index.js
@@ -48,7 +48,7 @@ module.exports = router;
  *       schema:
  *         type: string
  *       required: false
- *       description: Optional encryption password for end-to-end encrypted budgets. Only needed in the first interaction with the encrypted budget, subsequent requests don't need to provide this value
+ *       description: Optional encryption password for end-to-end encrypted budgets. You may need to provide it again after a service restart or Actual API client reset before reopening a cached encrypted budget
  *   schemas:
  *     GeneralError:
  *      type: object


### PR DESCRIPTION
Hi,
I am using actual-http-api to access multiple individually encrypted Actual budgets, and I pass the encryption key to the API with every request. Initially, this works fine, but after some time requests start failing with errors like:

```
Unknown error while interacting with Actual Api. See server logs for more information Error
    at handlers$1.api/sync (/usr/src/app/node_modules/@actual-app/api/dist/index.js:114759:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
Ignoring unhandledRejection caused by Actual api library
Syncing since 2026-06-03T15:00:10.925Z-000A-9a146ba1cd1a0f4e 0 (attempt: 0)
Error: missing-key
    at getKey (/usr/src/app/node_modules/@actual-app/api/dist/index.js:63958:52)
    at decrypt (/usr/src/app/node_modules/@actual-app/api/dist/index.js:63968:19)
    at decode (/usr/src/app/node_modules/@actual-app/api/dist/index.js:64054:23)
    at _fullSync (/usr/src/app/node_modules/@actual-app/api/dist/index.js:66807:20)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async /usr/src/app/node_modules/@actual-app/api/dist/index.js:66735:14
    at async initialFullSync (/usr/src/app/node_modules/@actual-app/api/dist/index.js:66724:17)
    at async Object.syncBudget [as sync-budget] (/usr/src/app/node_modules/@actual-app/api/dist/index.js:123294:9)
    at async handlers$1.api/sync (/usr/src/app/node_modules/@actual-app/api/dist/index.js:114758:17)
SyncError: SyncError: decrypt-failure
    at decode (/usr/src/app/node_modules/@actual-app/api/dist/index.js:64062:11)
```

Restarting the container fixes the problem temporarily.

The problem seems to be that cached budgets are reopened with `loadBudget(...) + sync()`, which works until the underlying `@actual-app/api` client gets reset and loses the in-memory encryption key. At that point, the wrapper still treats the budget as cached, but the key is gone, so sync fails. (disclaimer: AI analysis)

This PR fixes that with a minimal change: when a cached budget request includes `budget-encryption-password`, it uses `downloadBudget(syncId, { password })` again instead of `loadBudget(...) + sync()`. That re-establishes the encryption key for encrypted budgets while leaving the normal cached path unchanged for requests without the header.

I am not sure if this is the best solution. But I’ve been running this version for some time now and haven’t seen the issue again. What do you think of this solution?