### PR TITLE
chore: Bump @actual-app/api to 26.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "26.8.1",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "^26.8.1",
+        "@actual-app/api": "^26.9.0",
         "archiver": "^8.0.0",
         "express": "^5.2.1",
         "js-yaml": "^5.4.1",
@@ -26,12 +26,12 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.1.tgz",
-      "integrity": "sha512-FpOjTdbXEUlph1pElNANT/y2TwNn3vGbR/4SRRtic6x2kZIrrKZBCx4+X5/GobVNLPGJX66p6tVcki41nqpPZA==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.9.0.tgz",
+      "integrity": "sha512-jlDN/RWOqa5ToIM3k4ShpwMIh9sCMUqYYsS5IvAIykKscGkHdmJ+0YqcLhJrG3qOkWplArp8TNknJWASUMR5AA==",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/core": "26.8.1",
+        "@actual-app/core": "26.9.0",
         "@actual-app/crdt": "3.1.1",
         "better-sqlite3": "^12.11.1",
         "compare-versions": "^6.1.1",
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@actual-app/core": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.1.tgz",
-      "integrity": "sha512-1uvhHqZ4QeBeOkEzLr+OAvRKQWSZr1E+oO32V2v4HgqwUF1MUkHtUZqEaf7WQswaF8hNNTI0GeL2goVbTJu6xg==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.9.0.tgz",
+      "integrity": "sha512-Nn6rxZQRoCYIaHtc0ZSAinA7RgYV24QuHW+XE3aJWBu9qcttjSUIBMQrBo+W960C++FcityvkIi3Yj1XIUGy+g==",
       "license": "ISC",
       "dependencies": {
         "@jlongster/sql.js": "^1.6.7",
@@ -3473,14 +3473,15 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
-      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
       "license": "MIT",
       "workspaces": [
         "docs",
         "benchmarks",
-        "tests/types"
+        "tests/types",
+        "tests/browser-compat"
       ]
     },
     "node_modules/escalade": {
@@ -4130,9 +4131,9 @@
       }
     },
     "node_modules/hyperformula": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
-      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.4.0.tgz",
+      "integrity": "sha512-w1N11JWfdHedHpNoSgYBd3Mz7e1yr1BEQ+g4GFJbLv+qlYVXyC4I8xy1mSwj13FhcoDBGNU5yxPCdXB6vwaYaA==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "chevrotain": "^6.5.0",
@@ -5322,9 +5323,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -6165,6 +6166,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7082,11 +7084,11 @@
   },
   "dependencies": {
     "@actual-app/api": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.1.tgz",
-      "integrity": "sha512-FpOjTdbXEUlph1pElNANT/y2TwNn3vGbR/4SRRtic6x2kZIrrKZBCx4+X5/GobVNLPGJX66p6tVcki41nqpPZA==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.9.0.tgz",
+      "integrity": "sha512-jlDN/RWOqa5ToIM3k4ShpwMIh9sCMUqYYsS5IvAIykKscGkHdmJ+0YqcLhJrG3qOkWplArp8TNknJWASUMR5AA==",
       "requires": {
-        "@actual-app/core": "26.8.1",
+        "@actual-app/core": "26.9.0",
         "@actual-app/crdt": "3.1.1",
         "better-sqlite3": "^12.11.1",
         "compare-versions": "^6.1.1",
@@ -7094,9 +7096,9 @@
       }
     },
     "@actual-app/core": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.1.tgz",
-      "integrity": "sha512-1uvhHqZ4QeBeOkEzLr+OAvRKQWSZr1E+oO32V2v4HgqwUF1MUkHtUZqEaf7WQswaF8hNNTI0GeL2goVbTJu6xg==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.9.0.tgz",
+      "integrity": "sha512-Nn6rxZQRoCYIaHtc0ZSAinA7RgYV24QuHW+XE3aJWBu9qcttjSUIBMQrBo+W960C++FcityvkIi3Yj1XIUGy+g==",
       "requires": {
         "@jlongster/sql.js": "^1.6.7",
         "@rschedule/core": "^1.5.0",
@@ -9266,9 +9268,9 @@
       }
     },
     "es-toolkit": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
-      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA=="
     },
     "escalade": {
       "version": "3.2.0",
@@ -9692,9 +9694,9 @@
       "dev": true
     },
     "hyperformula": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
-      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.4.0.tgz",
+      "integrity": "sha512-w1N11JWfdHedHpNoSgYBd3Mz7e1yr1BEQ+g4GFJbLv+qlYVXyC4I8xy1mSwj13FhcoDBGNU5yxPCdXB6vwaYaA==",
       "requires": {
         "chevrotain": "^6.5.0",
         "tiny-emitter": "^2.1.0"
@@ -10521,9 +10523,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "requires": {
         "semver": "^7.3.5"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "jhonderson",
   "license": "MIT",
   "dependencies": {
-    "@actual-app/api": "^26.8.1",
+    "@actual-app/api": "^26.9.0",
     "archiver": "^8.0.0",
     "express": "^5.2.1",
     "js-yaml": "^5.4.1",


### PR DESCRIPTION
Client 26.8.1 results in an "invalid schema" error when trying to interact with a 26.9.0 server. Bumping allowed it to work again for me with no further changes required