### PR TITLE
Upgrade @actual-app/api to 26.9.0 and expose payeeNameNormalization

### DIFF
--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -515,6 +515,7 @@ describe('Budget Module', () => {
         defaultCleared: true,
         dryRun: false,
         reimportDeleted: false,
+        payeeNameNormalization: 'title-case',
       });
     });
 
@@ -524,11 +525,25 @@ describe('Budget Module', () => {
         defaultCleared: false,
         dryRun: true,
         reimportDeleted: true,
+        payeeNameNormalization: 'original',
       };
 
       await budget.importTransactions('acc1', transactions, options);
 
       expect(mockActualApi.importTransactions).toHaveBeenCalledWith('acc1', transactions, options);
+    });
+
+    it('should forward payeeNameNormalization when it is the only option supplied', async () => {
+      const transactions = [{ amount: 100 }];
+
+      await budget.importTransactions('acc1', transactions, { payeeNameNormalization: 'original' });
+
+      expect(mockActualApi.importTransactions).toHaveBeenCalledWith('acc1', transactions, {
+        defaultCleared: true,
+        dryRun: false,
+        reimportDeleted: false,
+        payeeNameNormalization: 'original',
+      });
     });
 
     it('should update a transaction', async () => {

--- a/__tests__/v1/routes/transactions.test.js
+++ b/__tests__/v1/routes/transactions.test.js
@@ -434,6 +434,7 @@ describe('Transactions Routes', () => {
         defaultCleared: true,
         dryRun: false,
         reimportDeleted: false,
+        payeeNameNormalization: 'title-case',
       });
       expect(mockRes.json).toHaveBeenCalled();
     });
@@ -456,6 +457,7 @@ describe('Transactions Routes', () => {
         defaultCleared: false,
         dryRun: true,
         reimportDeleted: true,
+        payeeNameNormalization: 'original',
       };
 
       await handler(mockReq, mockRes, mockNext);
@@ -464,8 +466,28 @@ describe('Transactions Routes', () => {
         defaultCleared: false,
         dryRun: true,
         reimportDeleted: true,
+        payeeNameNormalization: 'original',
       });
       expect(mockRes.json).toHaveBeenCalled();
+    });
+
+    it('should reject an invalid payeeNameNormalization value', async () => {
+      const transactionsModule = require('../../../src/v1/routes/transactions');
+      transactionsModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/accounts/:accountId/transactions/import'];
+      mockReq.params.accountId = 'acc1';
+      mockReq.body = {
+        transactions: [{ date: '2023-08-01', amount: -50, account: 'acc1' }],
+        payeeNameNormalization: 'upper-case',
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.importTransactions).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'payeeNameNormalization must be one of original, title-case',
+      }));
     });
 
     it('should reject without transactions array', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "26.8.1",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "^26.8.1",
+        "@actual-app/api": "^26.9.0",
         "archiver": "^8.0.0",
         "express": "^5.2.1",
         "js-yaml": "^5.4.1",
@@ -26,12 +26,12 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.1.tgz",
-      "integrity": "sha512-FpOjTdbXEUlph1pElNANT/y2TwNn3vGbR/4SRRtic6x2kZIrrKZBCx4+X5/GobVNLPGJX66p6tVcki41nqpPZA==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.9.0.tgz",
+      "integrity": "sha512-jlDN/RWOqa5ToIM3k4ShpwMIh9sCMUqYYsS5IvAIykKscGkHdmJ+0YqcLhJrG3qOkWplArp8TNknJWASUMR5AA==",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/core": "26.8.1",
+        "@actual-app/core": "26.9.0",
         "@actual-app/crdt": "3.1.1",
         "better-sqlite3": "^12.11.1",
         "compare-versions": "^6.1.1",
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@actual-app/core": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.1.tgz",
-      "integrity": "sha512-1uvhHqZ4QeBeOkEzLr+OAvRKQWSZr1E+oO32V2v4HgqwUF1MUkHtUZqEaf7WQswaF8hNNTI0GeL2goVbTJu6xg==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.9.0.tgz",
+      "integrity": "sha512-Nn6rxZQRoCYIaHtc0ZSAinA7RgYV24QuHW+XE3aJWBu9qcttjSUIBMQrBo+W960C++FcityvkIi3Yj1XIUGy+g==",
       "license": "ISC",
       "dependencies": {
         "@jlongster/sql.js": "^1.6.7",
@@ -3473,14 +3473,15 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
-      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
       "license": "MIT",
       "workspaces": [
         "docs",
         "benchmarks",
-        "tests/types"
+        "tests/types",
+        "tests/browser-compat"
       ]
     },
     "node_modules/escalade": {
@@ -4130,9 +4131,9 @@
       }
     },
     "node_modules/hyperformula": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
-      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.4.0.tgz",
+      "integrity": "sha512-w1N11JWfdHedHpNoSgYBd3Mz7e1yr1BEQ+g4GFJbLv+qlYVXyC4I8xy1mSwj13FhcoDBGNU5yxPCdXB6vwaYaA==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "chevrotain": "^6.5.0",
@@ -5322,9 +5323,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -6165,6 +6166,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7082,11 +7084,11 @@
   },
   "dependencies": {
     "@actual-app/api": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.1.tgz",
-      "integrity": "sha512-FpOjTdbXEUlph1pElNANT/y2TwNn3vGbR/4SRRtic6x2kZIrrKZBCx4+X5/GobVNLPGJX66p6tVcki41nqpPZA==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.9.0.tgz",
+      "integrity": "sha512-jlDN/RWOqa5ToIM3k4ShpwMIh9sCMUqYYsS5IvAIykKscGkHdmJ+0YqcLhJrG3qOkWplArp8TNknJWASUMR5AA==",
       "requires": {
-        "@actual-app/core": "26.8.1",
+        "@actual-app/core": "26.9.0",
         "@actual-app/crdt": "3.1.1",
         "better-sqlite3": "^12.11.1",
         "compare-versions": "^6.1.1",
@@ -7094,9 +7096,9 @@
       }
     },
     "@actual-app/core": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.1.tgz",
-      "integrity": "sha512-1uvhHqZ4QeBeOkEzLr+OAvRKQWSZr1E+oO32V2v4HgqwUF1MUkHtUZqEaf7WQswaF8hNNTI0GeL2goVbTJu6xg==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.9.0.tgz",
+      "integrity": "sha512-Nn6rxZQRoCYIaHtc0ZSAinA7RgYV24QuHW+XE3aJWBu9qcttjSUIBMQrBo+W960C++FcityvkIi3Yj1XIUGy+g==",
       "requires": {
         "@jlongster/sql.js": "^1.6.7",
         "@rschedule/core": "^1.5.0",
@@ -9266,9 +9268,9 @@
       }
     },
     "es-toolkit": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
-      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA=="
     },
     "escalade": {
       "version": "3.2.0",
@@ -9692,9 +9694,9 @@
       "dev": true
     },
     "hyperformula": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
-      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.4.0.tgz",
+      "integrity": "sha512-w1N11JWfdHedHpNoSgYBd3Mz7e1yr1BEQ+g4GFJbLv+qlYVXyC4I8xy1mSwj13FhcoDBGNU5yxPCdXB6vwaYaA==",
       "requires": {
         "chevrotain": "^6.5.0",
         "tiny-emitter": "^2.1.0"
@@ -10521,9 +10523,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "requires": {
         "semver": "^7.3.5"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-http-api",
-  "version": "26.8.1",
+  "version": "26.9.0",
   "description": "Basic Actual Budgeting API exposed through HTTP endpoints",
   "main": "server.js",
   "bin": "./server.js",
@@ -13,7 +13,7 @@
   "author": "jhonderson",
   "license": "MIT",
   "dependencies": {
-    "@actual-app/api": "^26.8.1",
+    "@actual-app/api": "^26.9.0",
     "archiver": "^8.0.0",
     "express": "^5.2.1",
     "js-yaml": "^5.4.1",

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -166,11 +166,13 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     defaultCleared = true,
     dryRun = false,
     reimportDeleted = false,
+    payeeNameNormalization = 'title-case',
   } = {}) {
     return actualApi.importTransactions(accountId, transactions, {
       defaultCleared,
       dryRun,
       reimportDeleted,
+      payeeNameNormalization,
     });
   }
 

--- a/src/v1/routes/transactions.js
+++ b/src/v1/routes/transactions.js
@@ -1,5 +1,7 @@
 const { isEmpty, paginate, validatePaginationParameters } = require('../../utils/utils');
 
+const PAYEE_NAME_NORMALIZATIONS = ['original', 'title-case'];
+
 /**
  * @swagger
  * tags:
@@ -330,6 +332,11 @@ module.exports = (router) => {
   *               reimportDeleted:
   *                 type: boolean
   *                 default: false
+  *               payeeNameNormalization:
+  *                 type: string
+  *                 enum: [title-case, original]
+  *                 default: title-case
+  *                 description: 'How `payee_name` is normalized before import. `title-case` converts it to title case, `original` keeps it exactly as supplied (useful for acronyms such as "NY" or "BC")'
    *             examples:
    *               - transactions:
    *                 - account: "729cb492-4eab-468b-9522-75d455cded22"
@@ -341,6 +348,7 @@ module.exports = (router) => {
   *                 defaultCleared: true
   *                 dryRun: false
   *                 reimportDeleted: false
+  *                 payeeNameNormalization: 'title-case'
    *     responses:
    *       '201':
    *         description: Ids of transactions add and updated
@@ -389,11 +397,13 @@ module.exports = (router) => {
   router.post('/budgets/:budgetSyncId/accounts/:accountId/transactions/import', async (req, res, next) => {
     try {
       validateTransactionsArray(req.body.transactions);
+      validatePayeeNameNormalization(req.body.payeeNameNormalization);
       await validateAccountExists(res, req.params.accountId);
       const options = {
         defaultCleared: req.body.defaultCleared ?? true,
         dryRun: req.body.dryRun ?? false,
         reimportDeleted: req.body.reimportDeleted ?? false,
+        payeeNameNormalization: req.body.payeeNameNormalization ?? 'title-case',
       };
       res.json({'data': await res.locals.budget.importTransactions(req.params.accountId, req.body.transactions, options)}).status(201);
     } catch(err) {
@@ -582,6 +592,13 @@ module.exports = (router) => {
   function validateTransactionsArray(transactions) {
     if (transactions === undefined || !transactions.length) {
       throw new Error('List of transactions is required');
+    }
+  }
+
+  function validatePayeeNameNormalization(payeeNameNormalization) {
+    if (payeeNameNormalization !== undefined
+      && !PAYEE_NAME_NORMALIZATIONS.includes(payeeNameNormalization)) {
+      throw new Error(`payeeNameNormalization must be one of ${PAYEE_NAME_NORMALIZATIONS.join(', ')}`);
     }
   }
 }


### PR DESCRIPTION
Upgrades `@actual-app/api` from 26.8.1 to 26.9.0 ([release notes](https://actualbudget.org/blog/release-26.9.0/)) and surfaces the one new option that affects this project's HTTP surface.

## Changes

- `package.json` / `package-lock.json`: `@actual-app/api` `^26.8.1` -> `^26.9.0`, package version `26.8.1` -> `26.9.0`
- `src/v1/budget.js`: `importTransactions` now forwards `payeeNameNormalization`, defaulting to `title-case`
- `src/v1/routes/transactions.js`: `POST /budgets/{budgetSyncId}/accounts/{accountId}/transactions/import` accepts `payeeNameNormalization` in the body, validates it against `original` / `title-case`, and documents it in Swagger
- `__tests__/v1/budget.test.js`, `__tests__/v1/routes/transactions.test.js`: tests for the default, the explicit value, and a `400` on an invalid value

## Why

26.9.0 adds a `payeeNameNormalization` option to `importTransactions` (actualbudget/actual#8710). Previously import always title-cased `payee_name`, which corrupts acronyms - `"NY"` became `"Ny"`, `"BC"` became `"Bc"`. Passing `original` preserves the name exactly as supplied.

The default stays `title-case`, so existing clients see no behaviour change.

## Notes on the rest of 26.9.0

- **Rules API default stage fix** - the library now maps `stage: "default"` to `null` internally. This repo already documents `"pre" | "default" | "post"` in the `Rule` schema, so the fix makes the documented behaviour work without any change here.
- **Node 24 release artifacts** - applies to Actual's own Docker images. `@actual-app/api@26.9.0` still declares `engines.node >= 20`, so `Dockerfile` stays on `node:22-alpine`.

## Testing

`npm test` - 412 passed, 19 suites (410 before this change, +2 new).