### PR TITLE
Expose account groups CRUD endpoints (26.9.0)

### DIFF
--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -60,6 +60,12 @@ describe('Budget Module', () => {
       deleteAccount: jest.fn().mockResolvedValue(undefined),
       closeAccount: jest.fn().mockResolvedValue(undefined),
       reopenAccount: jest.fn().mockResolvedValue(undefined),
+      getAccountGroups: jest.fn().mockResolvedValue([
+        { id: 'ag1', name: 'Everyday Banking' }
+      ]),
+      createAccountGroup: jest.fn().mockResolvedValue('ag2'),
+      updateAccountGroup: jest.fn().mockResolvedValue(undefined),
+      deleteAccountGroup: jest.fn().mockResolvedValue(undefined),
       getTransactions: jest.fn().mockResolvedValue([
         { id: 'txn1', amount: 100, payee: 'Store' }
       ]),
@@ -301,6 +307,24 @@ describe('Budget Module', () => {
       expect(accounts[0].id).toBe('acc1');
     });
 
+    it('should select account_group_id so grouped accounts are identifiable', async () => {
+      runAqlQuery.mockResolvedValueOnce({
+        data: [
+          { id: 'acc1', name: 'Checking', offbudget: false, closed: false, account_group_id: 'ag1' }
+        ]
+      });
+
+      const accounts = await budget.getAccounts();
+
+      const selectCall = mockActualApi.q.mock.results
+        .map(result => result.value.select)
+        .find(select => select.mock.calls.length > 0);
+      expect(selectCall).toHaveBeenCalledWith(
+        expect.arrayContaining(['id', 'name', 'offbudget', 'closed', 'account_group_id'])
+      );
+      expect(accounts[0].account_group_id).toBe('ag1');
+    });
+
     it('should get accounts with balances when includeBalances is true', async () => {
       runAqlQuery
         .mockResolvedValueOnce({
@@ -456,6 +480,37 @@ describe('Budget Module', () => {
     it('should reopen an account', async () => {
       await budget.reopenAccount('acc1');
       expect(mockActualApi.reopenAccount).toHaveBeenCalledWith('acc1');
+    });
+
+    it('should get account groups', async () => {
+      const result = await budget.getAccountGroups();
+      expect(mockActualApi.getAccountGroups).toHaveBeenCalled();
+      expect(result).toEqual([{ id: 'ag1', name: 'Everyday Banking' }]);
+    });
+
+    it('should get a single account group by id', async () => {
+      const result = await budget.getAccountGroup('ag1');
+      expect(result).toEqual({ id: 'ag1', name: 'Everyday Banking' });
+    });
+
+    it('should return undefined for an unknown account group id', async () => {
+      const result = await budget.getAccountGroup('nonexistent');
+      expect(result).toBeUndefined();
+    });
+
+    it('should create an account group', async () => {
+      await budget.createAccountGroup({ name: 'Savings' });
+      expect(mockActualApi.createAccountGroup).toHaveBeenCalledWith({ name: 'Savings' });
+    });
+
+    it('should update an account group', async () => {
+      await budget.updateAccountGroup('ag1', { name: 'Renamed' });
+      expect(mockActualApi.updateAccountGroup).toHaveBeenCalledWith('ag1', { name: 'Renamed' });
+    });
+
+    it('should delete an account group', async () => {
+      await budget.deleteAccountGroup('ag1');
+      expect(mockActualApi.deleteAccountGroup).toHaveBeenCalledWith('ag1');
     });
   });
 

--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -515,6 +515,7 @@ describe('Budget Module', () => {
         defaultCleared: true,
         dryRun: false,
         reimportDeleted: false,
+        payeeNameNormalization: 'title-case',
       });
     });
 
@@ -524,11 +525,25 @@ describe('Budget Module', () => {
         defaultCleared: false,
         dryRun: true,
         reimportDeleted: true,
+        payeeNameNormalization: 'original',
       };
 
       await budget.importTransactions('acc1', transactions, options);
 
       expect(mockActualApi.importTransactions).toHaveBeenCalledWith('acc1', transactions, options);
+    });
+
+    it('should forward payeeNameNormalization when it is the only option supplied', async () => {
+      const transactions = [{ amount: 100 }];
+
+      await budget.importTransactions('acc1', transactions, { payeeNameNormalization: 'original' });
+
+      expect(mockActualApi.importTransactions).toHaveBeenCalledWith('acc1', transactions, {
+        defaultCleared: true,
+        dryRun: false,
+        reimportDeleted: false,
+        payeeNameNormalization: 'original',
+      });
     });
 
     it('should update a transaction', async () => {

--- a/__tests__/v1/routes/account-groups.test.js
+++ b/__tests__/v1/routes/account-groups.test.js
@@ -1,0 +1,235 @@
+process.env.API_KEY = process.env.API_KEY || 'test-api-key';
+process.env.ACTUAL_SERVER_PASSWORD = process.env.ACTUAL_SERVER_PASSWORD || 'test-password';
+
+describe('Account Groups Routes', () => {
+  let mockRouter;
+  let mockBudget;
+  let mockReq;
+  let mockRes;
+  let mockNext;
+  let handlers;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    handlers = {};
+
+    mockRouter = {
+      get: jest.fn((path, handler) => {
+        handlers[`GET ${path}`] = handler;
+      }),
+      post: jest.fn((path, handler) => {
+        handlers[`POST ${path}`] = handler;
+      }),
+      patch: jest.fn((path, handler) => {
+        handlers[`PATCH ${path}`] = handler;
+      }),
+      delete: jest.fn((path, handler) => {
+        handlers[`DELETE ${path}`] = handler;
+      }),
+    };
+
+    mockBudget = {
+      getAccountGroups: jest.fn().mockResolvedValue([
+        { id: 'ag1', name: 'Everyday Banking' },
+        { id: 'ag2', name: 'Savings' }
+      ]),
+      getAccountGroup: jest.fn().mockResolvedValue({ id: 'ag1', name: 'Everyday Banking' }),
+      createAccountGroup: jest.fn().mockResolvedValue('new-account-group'),
+      updateAccountGroup: jest.fn().mockResolvedValue(undefined),
+      deleteAccountGroup: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockReq = {
+      params: {},
+      body: {},
+      query: {}
+    };
+
+    mockRes = {
+      json: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+      locals: {
+        budget: mockBudget,
+      },
+    };
+
+    mockNext = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('GET /budgets/:budgetSyncId/accountgroups', () => {
+    it('should register the route', () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      expect(mockRouter.get).toHaveBeenCalledWith(
+        '/budgets/:budgetSyncId/accountgroups',
+        expect.any(Function)
+      );
+    });
+
+    it('should return the list of account groups', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      await handlers['GET /budgets/:budgetSyncId/accountgroups'](mockReq, mockRes, mockNext);
+
+      expect(mockBudget.getAccountGroups).toHaveBeenCalled();
+      expect(mockRes.json).toHaveBeenCalledWith({
+        data: [
+          { id: 'ag1', name: 'Everyday Banking' },
+          { id: 'ag2', name: 'Savings' }
+        ]
+      });
+    });
+
+    it('should forward errors to next', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      const error = new Error('Database error');
+      mockBudget.getAccountGroups.mockRejectedValueOnce(error);
+
+      await handlers['GET /budgets/:budgetSyncId/accountgroups'](mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('POST /budgets/:budgetSyncId/accountgroups', () => {
+    it('should create an account group', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      mockReq.body = { account_group: { name: 'Everyday Banking' } };
+
+      await handlers['POST /budgets/:budgetSyncId/accountgroups'](mockReq, mockRes, mockNext);
+
+      expect(mockBudget.createAccountGroup).toHaveBeenCalledWith({ name: 'Everyday Banking' });
+      expect(mockRes.json).toHaveBeenCalledWith({ data: 'new-account-group' });
+    });
+
+    it('should reject an empty body', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      mockReq.body = {};
+
+      await handlers['POST /budgets/:budgetSyncId/accountgroups'](mockReq, mockRes, mockNext);
+
+      expect(mockBudget.createAccountGroup).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'account_group information is required'
+      }));
+    });
+
+    it('should reject a body that is not wrapped in account_group', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      mockReq.body = { name: 'Everyday Banking' };
+
+      await handlers['POST /budgets/:budgetSyncId/accountgroups'](mockReq, mockRes, mockNext);
+
+      expect(mockBudget.createAccountGroup).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('GET /budgets/:budgetSyncId/accountgroups/:accountGroupId', () => {
+    it('should return a single account group', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      mockReq.params.accountGroupId = 'ag1';
+
+      await handlers['GET /budgets/:budgetSyncId/accountgroups/:accountGroupId'](mockReq, mockRes, mockNext);
+
+      expect(mockBudget.getAccountGroup).toHaveBeenCalledWith('ag1');
+      expect(mockRes.json).toHaveBeenCalledWith({
+        data: { id: 'ag1', name: 'Everyday Banking' }
+      });
+    });
+
+    it('should return not found for a nonexistent account group', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      mockReq.params.accountGroupId = 'nonexistent';
+      mockBudget.getAccountGroup.mockResolvedValueOnce(undefined);
+
+      await handlers['GET /budgets/:budgetSyncId/accountgroups/:accountGroupId'](mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Account group not found'
+      }));
+    });
+  });
+
+  describe('PATCH /budgets/:budgetSyncId/accountgroups/:accountGroupId', () => {
+    it('should update an account group', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      mockReq.params.accountGroupId = 'ag1';
+      mockReq.body = { account_group: { name: 'Renamed' } };
+
+      await handlers['PATCH /budgets/:budgetSyncId/accountgroups/:accountGroupId'](mockReq, mockRes, mockNext);
+
+      expect(mockBudget.updateAccountGroup).toHaveBeenCalledWith('ag1', { name: 'Renamed' });
+      expect(mockRes.json).toHaveBeenCalledWith({ message: 'Account group updated' });
+    });
+
+    it('should reject an empty body', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      mockReq.params.accountGroupId = 'ag1';
+      mockReq.body = {};
+
+      await handlers['PATCH /budgets/:budgetSyncId/accountgroups/:accountGroupId'](mockReq, mockRes, mockNext);
+
+      expect(mockBudget.updateAccountGroup).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'account_group information is required'
+      }));
+    });
+
+    it('should return not found for a nonexistent account group', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      mockReq.params.accountGroupId = 'nonexistent';
+      mockReq.body = { account_group: { name: 'Renamed' } };
+      mockBudget.getAccountGroup.mockResolvedValueOnce(undefined);
+
+      await handlers['PATCH /budgets/:budgetSyncId/accountgroups/:accountGroupId'](mockReq, mockRes, mockNext);
+
+      expect(mockBudget.updateAccountGroup).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Account group not found'
+      }));
+    });
+  });
+
+  describe('DELETE /budgets/:budgetSyncId/accountgroups/:accountGroupId', () => {
+    it('should delete an account group', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      mockReq.params.accountGroupId = 'ag1';
+
+      await handlers['DELETE /budgets/:budgetSyncId/accountgroups/:accountGroupId'](mockReq, mockRes, mockNext);
+
+      expect(mockBudget.deleteAccountGroup).toHaveBeenCalledWith('ag1');
+      expect(mockRes.json).toHaveBeenCalledWith({ message: 'Account group deleted' });
+    });
+
+    it('should return not found for a nonexistent account group', async () => {
+      require('../../../src/v1/routes/account-groups')(mockRouter);
+
+      mockReq.params.accountGroupId = 'nonexistent';
+      mockBudget.getAccountGroup.mockResolvedValueOnce(undefined);
+
+      await handlers['DELETE /budgets/:budgetSyncId/accountgroups/:accountGroupId'](mockReq, mockRes, mockNext);
+
+      expect(mockBudget.deleteAccountGroup).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Account group not found'
+      }));
+    });
+  });
+});

--- a/__tests__/v1/routes/transactions.test.js
+++ b/__tests__/v1/routes/transactions.test.js
@@ -434,6 +434,7 @@ describe('Transactions Routes', () => {
         defaultCleared: true,
         dryRun: false,
         reimportDeleted: false,
+        payeeNameNormalization: 'title-case',
       });
       expect(mockRes.json).toHaveBeenCalled();
     });
@@ -456,6 +457,7 @@ describe('Transactions Routes', () => {
         defaultCleared: false,
         dryRun: true,
         reimportDeleted: true,
+        payeeNameNormalization: 'original',
       };
 
       await handler(mockReq, mockRes, mockNext);
@@ -464,8 +466,28 @@ describe('Transactions Routes', () => {
         defaultCleared: false,
         dryRun: true,
         reimportDeleted: true,
+        payeeNameNormalization: 'original',
       });
       expect(mockRes.json).toHaveBeenCalled();
+    });
+
+    it('should reject an invalid payeeNameNormalization value', async () => {
+      const transactionsModule = require('../../../src/v1/routes/transactions');
+      transactionsModule(mockRouter);
+
+      const handler = handlers['POST /budgets/:budgetSyncId/accounts/:accountId/transactions/import'];
+      mockReq.params.accountId = 'acc1';
+      mockReq.body = {
+        transactions: [{ date: '2023-08-01', amount: -50, account: 'acc1' }],
+        payeeNameNormalization: 'upper-case',
+      };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.importTransactions).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'payeeNameNormalization must be one of original, title-case',
+      }));
     });
 
     it('should reject without transactions array', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "26.8.1",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "^26.8.1",
+        "@actual-app/api": "^26.9.0",
         "archiver": "^8.0.0",
         "express": "^5.2.1",
         "js-yaml": "^5.4.1",
@@ -26,12 +26,12 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.1.tgz",
-      "integrity": "sha512-FpOjTdbXEUlph1pElNANT/y2TwNn3vGbR/4SRRtic6x2kZIrrKZBCx4+X5/GobVNLPGJX66p6tVcki41nqpPZA==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.9.0.tgz",
+      "integrity": "sha512-jlDN/RWOqa5ToIM3k4ShpwMIh9sCMUqYYsS5IvAIykKscGkHdmJ+0YqcLhJrG3qOkWplArp8TNknJWASUMR5AA==",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/core": "26.8.1",
+        "@actual-app/core": "26.9.0",
         "@actual-app/crdt": "3.1.1",
         "better-sqlite3": "^12.11.1",
         "compare-versions": "^6.1.1",
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@actual-app/core": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.1.tgz",
-      "integrity": "sha512-1uvhHqZ4QeBeOkEzLr+OAvRKQWSZr1E+oO32V2v4HgqwUF1MUkHtUZqEaf7WQswaF8hNNTI0GeL2goVbTJu6xg==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.9.0.tgz",
+      "integrity": "sha512-Nn6rxZQRoCYIaHtc0ZSAinA7RgYV24QuHW+XE3aJWBu9qcttjSUIBMQrBo+W960C++FcityvkIi3Yj1XIUGy+g==",
       "license": "ISC",
       "dependencies": {
         "@jlongster/sql.js": "^1.6.7",
@@ -3473,14 +3473,15 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
-      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
       "license": "MIT",
       "workspaces": [
         "docs",
         "benchmarks",
-        "tests/types"
+        "tests/types",
+        "tests/browser-compat"
       ]
     },
     "node_modules/escalade": {
@@ -4130,9 +4131,9 @@
       }
     },
     "node_modules/hyperformula": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
-      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.4.0.tgz",
+      "integrity": "sha512-w1N11JWfdHedHpNoSgYBd3Mz7e1yr1BEQ+g4GFJbLv+qlYVXyC4I8xy1mSwj13FhcoDBGNU5yxPCdXB6vwaYaA==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "chevrotain": "^6.5.0",
@@ -5322,9 +5323,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -6165,6 +6166,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7082,11 +7084,11 @@
   },
   "dependencies": {
     "@actual-app/api": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.1.tgz",
-      "integrity": "sha512-FpOjTdbXEUlph1pElNANT/y2TwNn3vGbR/4SRRtic6x2kZIrrKZBCx4+X5/GobVNLPGJX66p6tVcki41nqpPZA==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.9.0.tgz",
+      "integrity": "sha512-jlDN/RWOqa5ToIM3k4ShpwMIh9sCMUqYYsS5IvAIykKscGkHdmJ+0YqcLhJrG3qOkWplArp8TNknJWASUMR5AA==",
       "requires": {
-        "@actual-app/core": "26.8.1",
+        "@actual-app/core": "26.9.0",
         "@actual-app/crdt": "3.1.1",
         "better-sqlite3": "^12.11.1",
         "compare-versions": "^6.1.1",
@@ -7094,9 +7096,9 @@
       }
     },
     "@actual-app/core": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.1.tgz",
-      "integrity": "sha512-1uvhHqZ4QeBeOkEzLr+OAvRKQWSZr1E+oO32V2v4HgqwUF1MUkHtUZqEaf7WQswaF8hNNTI0GeL2goVbTJu6xg==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.9.0.tgz",
+      "integrity": "sha512-Nn6rxZQRoCYIaHtc0ZSAinA7RgYV24QuHW+XE3aJWBu9qcttjSUIBMQrBo+W960C++FcityvkIi3Yj1XIUGy+g==",
       "requires": {
         "@jlongster/sql.js": "^1.6.7",
         "@rschedule/core": "^1.5.0",
@@ -9266,9 +9268,9 @@
       }
     },
     "es-toolkit": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
-      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA=="
     },
     "escalade": {
       "version": "3.2.0",
@@ -9692,9 +9694,9 @@
       "dev": true
     },
     "hyperformula": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
-      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.4.0.tgz",
+      "integrity": "sha512-w1N11JWfdHedHpNoSgYBd3Mz7e1yr1BEQ+g4GFJbLv+qlYVXyC4I8xy1mSwj13FhcoDBGNU5yxPCdXB6vwaYaA==",
       "requires": {
         "chevrotain": "^6.5.0",
         "tiny-emitter": "^2.1.0"
@@ -10521,9 +10523,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "requires": {
         "semver": "^7.3.5"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actual-http-api",
-  "version": "26.8.1",
+  "version": "26.9.0",
   "description": "Basic Actual Budgeting API exposed through HTTP endpoints",
   "main": "server.js",
   "bin": "./server.js",
@@ -13,7 +13,7 @@
   "author": "jhonderson",
   "license": "MIT",
   "dependencies": {
-    "@actual-app/api": "^26.8.1",
+    "@actual-app/api": "^26.9.0",
     "archiver": "^8.0.0",
     "express": "^5.2.1",
     "js-yaml": "^5.4.1",

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -166,11 +166,13 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     defaultCleared = true,
     dryRun = false,
     reimportDeleted = false,
+    payeeNameNormalization = 'title-case',
   } = {}) {
     return actualApi.importTransactions(accountId, transactions, {
       defaultCleared,
       dryRun,
       reimportDeleted,
+      payeeNameNormalization,
     });
   }
 

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -80,7 +80,7 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
 
     const accounts = (await runAqlQuery(
       actualApi.q('accounts')
-        .select(['id', 'name', 'offbudget', 'closed'])
+        .select(['id', 'name', 'offbudget', 'closed', 'account_group_id'])
         .filter(filter)
     ))?.data || [];
 
@@ -143,6 +143,27 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
 
   async function reopenAccount(accountId) {
     return actualApi.reopenAccount(accountId);
+  }
+
+  async function getAccountGroups() {
+    return actualApi.getAccountGroups();
+  }
+
+  async function getAccountGroup(accountGroupId) {
+    const accountGroups = await getAccountGroups();
+    return accountGroups.find((accountGroup) => accountGroupId == accountGroup.id);
+  }
+
+  async function createAccountGroup(accountGroup) {
+    return actualApi.createAccountGroup(accountGroup);
+  }
+
+  async function updateAccountGroup(accountGroupId, accountGroup) {
+    return actualApi.updateAccountGroup(accountGroupId, accountGroup);
+  }
+
+  async function deleteAccountGroup(accountGroupId) {
+    return actualApi.deleteAccountGroup(accountGroupId);
   }
 
   async function getTransactions(accountId, sinceDate, optionalUntilDate) {
@@ -465,6 +486,11 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     deleteAccount: deleteAccount,
     closeAccount: closeAccount,
     reopenAccount: reopenAccount,
+    getAccountGroups: getAccountGroups,
+    getAccountGroup: getAccountGroup,
+    createAccountGroup: createAccountGroup,
+    updateAccountGroup: updateAccountGroup,
+    deleteAccountGroup: deleteAccountGroup,
     getTransactions: getTransactions,
     addTransaction: addTransaction,
     addTransactions: addTransactions,

--- a/src/v1/routes/account-groups.js
+++ b/src/v1/routes/account-groups.js
@@ -1,0 +1,275 @@
+const { isEmpty } = require('../../utils/utils');
+
+/**
+ * @swagger
+ * tags:
+ *   - name: Account Groups
+ *     description: Endpoints for managing account groups. See [Accounts official documentation](https://actualbudget.org/docs/api/reference#accounts)
+ * components:
+ *   parameters:
+ *     accountGroupId:
+ *       name: accountGroupId
+ *       in: path
+ *       schema:
+ *         type: string
+ *       required: true
+ *       description: Account group id
+ *   schemas:
+ *     AccountGroup:
+ *       required:
+ *         - name
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         name:
+ *           type: string
+ */
+
+module.exports = (router) => {
+  /**
+   * @swagger
+   * /budgets/{budgetSyncId}/accountgroups:
+   *   get:
+   *     summary: Returns list of account groups
+   *     tags: [Account Groups]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     responses:
+   *       '200':
+   *         description: The list of account groups
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: array
+   *                   items:
+   *                     $ref: '#/components/schemas/AccountGroup'
+   *               examples:
+   *                 - data:
+   *                   - id: 'f733399d-4ccb-4758-b208-7422b27f650a'
+   *                     name: 'Everyday Banking'
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.get('/budgets/:budgetSyncId/accountgroups', async (req, res, next) => {
+    try {
+      res.json({'data': await res.locals.budget.getAccountGroups()});
+    } catch(err) {
+      next(err);
+    }
+  });
+
+  /**
+   * @swagger
+   * /budgets/{budgetSyncId}/accountgroups:
+   *   post:
+   *     summary: Creates an account group
+   *     tags: [Account Groups]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             required:
+   *               - account_group
+   *             type: object
+   *             properties:
+   *               account_group:
+   *                 $ref: '#/components/schemas/AccountGroup'
+   *             examples:
+   *               - account_group:
+   *                   name: 'Everyday Banking'
+   *     responses:
+   *       '200':
+   *         description: Id of the account group created
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: string
+   *                   description: Id of the account group created
+   *               examples:
+   *                 - data: 'f733399d-4ccb-4758-b208-7422b27f650a'
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.post('/budgets/:budgetSyncId/accountgroups', async (req, res, next) => {
+    try {
+      validateAccountGroupBody(req.body.account_group);
+      res.json({'data': await res.locals.budget.createAccountGroup(req.body.account_group)});
+    } catch(err) {
+      next(err);
+    }
+  });
+
+  /**
+   * @swagger
+   * /budgets/{budgetSyncId}/accountgroups/{accountGroupId}:
+   *   get:
+   *     summary: Returns an account group
+   *     tags: [Account Groups]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/accountGroupId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     responses:
+   *       '200':
+   *         description: The account group
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   $ref: '#/components/schemas/AccountGroup'
+   *               examples:
+   *                 - data:
+   *                     id: 'f733399d-4ccb-4758-b208-7422b27f650a'
+   *                     name: 'Everyday Banking'
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.get('/budgets/:budgetSyncId/accountgroups/:accountGroupId', async (req, res, next) => {
+    try {
+      res.json({'data': await getAccountGroupOrFail(res, req.params.accountGroupId)});
+    } catch(err) {
+      next(err);
+    }
+  });
+
+  /**
+   * @swagger
+   * /budgets/{budgetSyncId}/accountgroups/{accountGroupId}:
+   *   patch:
+   *     summary: Updates an account group
+   *     tags: [Account Groups]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/accountGroupId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             required:
+   *               - account_group
+   *             type: object
+   *             properties:
+   *               account_group:
+   *                 $ref: '#/components/schemas/AccountGroup'
+   *             examples:
+   *               - account_group:
+   *                   name: 'Everyday Banking'
+   *     responses:
+   *       '200':
+   *         description: Confirmation message
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/GeneralResponseMessage'
+   *               examples:
+   *                 - message: Account group updated
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.patch('/budgets/:budgetSyncId/accountgroups/:accountGroupId', async (req, res, next) => {
+    try {
+      validateAccountGroupBody(req.body.account_group);
+      await getAccountGroupOrFail(res, req.params.accountGroupId);
+      await res.locals.budget.updateAccountGroup(req.params.accountGroupId, req.body.account_group);
+      res.json({'message': 'Account group updated'});
+    } catch(err) {
+      next(err);
+    }
+  });
+
+  /**
+   * @swagger
+   * /budgets/{budgetSyncId}/accountgroups/{accountGroupId}:
+   *   delete:
+   *     summary: Deletes an account group. Accounts belonging to the group are kept and become ungrouped
+   *     tags: [Account Groups]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/accountGroupId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     responses:
+   *       '200':
+   *         description: Confirmation message
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/GeneralResponseMessage'
+   *               examples:
+   *                 - message: Account group deleted
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.delete('/budgets/:budgetSyncId/accountgroups/:accountGroupId', async (req, res, next) => {
+    try {
+      await getAccountGroupOrFail(res, req.params.accountGroupId);
+      await res.locals.budget.deleteAccountGroup(req.params.accountGroupId);
+      res.json({'message': 'Account group deleted'});
+    } catch(err) {
+      next(err);
+    }
+  });
+
+  async function getAccountGroupOrFail(res, accountGroupId) {
+    const accountGroup = await res.locals.budget.getAccountGroup(accountGroupId);
+    if (!accountGroup) {
+      throw new Error('Account group not found');
+    }
+    return accountGroup;
+  }
+
+  function validateAccountGroupBody(accountGroup) {
+    if (isEmpty(accountGroup)) {
+      throw new Error('account_group information is required');
+    }
+  }
+}

--- a/src/v1/routes/accounts.js
+++ b/src/v1/routes/accounts.js
@@ -53,6 +53,10 @@ const { isEmpty, formatDateToISOString, parseBoolean } = require('../../utils/ut
   *           type: boolean
   *         closed:
   *           type: boolean
+  *         account_group_id:
+  *           type: string
+  *           nullable: true
+  *           description: Id of the account group this account belongs to, or null when ungrouped
   *         clearedBalance:
   *           type: integer
   *           description: Cleared balance (only included when include_balances=true)

--- a/src/v1/routes/index.js
+++ b/src/v1/routes/index.js
@@ -16,6 +16,7 @@ router.use('/budgets/:budgetSyncId', authorizeRequest, async (req, res, next) =>
 
 require('./budget-months')(router);
 require('./accounts')(router);
+require('./account-groups')(router);
 require('./transactions')(router);
 require('./categories')(router);
 require('./rules')(router);

--- a/src/v1/routes/transactions.js
+++ b/src/v1/routes/transactions.js
@@ -1,5 +1,7 @@
 const { isEmpty, paginate, validatePaginationParameters } = require('../../utils/utils');
 
+const PAYEE_NAME_NORMALIZATIONS = ['original', 'title-case'];
+
 /**
  * @swagger
  * tags:
@@ -330,6 +332,11 @@ module.exports = (router) => {
   *               reimportDeleted:
   *                 type: boolean
   *                 default: false
+  *               payeeNameNormalization:
+  *                 type: string
+  *                 enum: [title-case, original]
+  *                 default: title-case
+  *                 description: 'How `payee_name` is normalized before import. `title-case` converts it to title case, `original` keeps it exactly as supplied (useful for acronyms such as "NY" or "BC")'
    *             examples:
    *               - transactions:
    *                 - account: "729cb492-4eab-468b-9522-75d455cded22"
@@ -341,6 +348,7 @@ module.exports = (router) => {
   *                 defaultCleared: true
   *                 dryRun: false
   *                 reimportDeleted: false
+  *                 payeeNameNormalization: 'title-case'
    *     responses:
    *       '201':
    *         description: Ids of transactions add and updated
@@ -389,11 +397,13 @@ module.exports = (router) => {
   router.post('/budgets/:budgetSyncId/accounts/:accountId/transactions/import', async (req, res, next) => {
     try {
       validateTransactionsArray(req.body.transactions);
+      validatePayeeNameNormalization(req.body.payeeNameNormalization);
       await validateAccountExists(res, req.params.accountId);
       const options = {
         defaultCleared: req.body.defaultCleared ?? true,
         dryRun: req.body.dryRun ?? false,
         reimportDeleted: req.body.reimportDeleted ?? false,
+        payeeNameNormalization: req.body.payeeNameNormalization ?? 'title-case',
       };
       res.json({'data': await res.locals.budget.importTransactions(req.params.accountId, req.body.transactions, options)}).status(201);
     } catch(err) {
@@ -582,6 +592,13 @@ module.exports = (router) => {
   function validateTransactionsArray(transactions) {
     if (transactions === undefined || !transactions.length) {
       throw new Error('List of transactions is required');
+    }
+  }
+
+  function validatePayeeNameNormalization(payeeNameNormalization) {
+    if (payeeNameNormalization !== undefined
+      && !PAYEE_NAME_NORMALIZATIONS.includes(payeeNameNormalization)) {
+      throw new Error(`payeeNameNormalization must be one of ${PAYEE_NAME_NORMALIZATIONS.join(', ')}`);
     }
   }
 }


### PR DESCRIPTION
> Depends on #121 (the 26.9.0 upgrade). Account groups do not exist in 26.8.1 at all, so this branch is stacked on that one - please merge #121 first, and this diff will shrink to just the account-groups changes.

26.9.0 added four account-group methods to `@actual-app/api` - `getAccountGroups`, `createAccountGroup`, `updateAccountGroup`, `deleteAccountGroup` - and none of them were reachable over HTTP. This adds the endpoints that cover them.

## New endpoints

| Method | Path |
|---|---|
| `GET` | `/budgets/{budgetSyncId}/accountgroups` |
| `POST` | `/budgets/{budgetSyncId}/accountgroups` |
| `GET` | `/budgets/{budgetSyncId}/accountgroups/{accountGroupId}` |
| `PATCH` | `/budgets/{budgetSyncId}/accountgroups/{accountGroupId}` |
| `DELETE` | `/budgets/{budgetSyncId}/accountgroups/{accountGroupId}` |

Request bodies wrap the entity under `account_group`, consistent with `category_group` on the category group endpoints.

## Changes

- `src/v1/routes/account-groups.js`: new route module, registered in `routes/index.js`
- `src/v1/budget.js`: wrappers for the four API methods, plus a `getAccountGroup(id)` lookup helper
- `src/v1/routes/accounts.js`: documents the new `account_group_id` field on the `Account` schema
- `__tests__/v1/routes/account-groups.test.js`, `__tests__/v1/budget.test.js`: tests

## Two things worth a second look

**`account_group_id` was being silently dropped.** Accounts gained an `account_group_id` field in 26.9.0, but `getAccounts` builds its own AQL projection (`.select([...])`) rather than using `api.getAccounts()`, so the new field never reached callers. Without it there is no way to tell which group an account belongs to, which makes the group endpoints fairly useless on their own - so I added it to the projection.

**The library does not check that a group exists.** `updateAccountGroup` and `deleteAccountGroup` issue a bare UPDATE/DELETE, so an unknown id silently succeeds rather than erroring. The routes therefore look the group up first and throw `Account group not found`, so `PATCH`/`DELETE`/`GET` on an unknown id return 404 like every other resource here.

I also confirmed deleting a group does **not** delete its accounts - the library nulls out their `account_group_id` - so the delete summary says the accounts become ungrouped.

## Testing

`npm test` - 432 passed, 20 suites (412 on #121, +20 here).

I verified the `account_group_id` assertion actually fails when the field is removed from the projection, so it is not passing vacuously. Also confirmed all five routes mount on the shared router and resolve their `$ref`s in the generated Swagger spec.