### PR TITLE
Expose budget preferences as GET /budgets/{budgetSyncId}/preferences (26.8.0)

### DIFF
--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -113,6 +113,10 @@ describe('Budget Module', () => {
       createTag: jest.fn().mockResolvedValue({ id: 'tag2', tag: 'newtag' }),
       updateTag: jest.fn().mockResolvedValue({ id: 'tag1', tag: 'updated' }),
       deleteTag: jest.fn().mockResolvedValue(undefined),
+      getPreferences: jest.fn().mockResolvedValue({
+        dateFormat: 'MM/dd/yyyy',
+        numberFormat: 'comma-dot',
+      }),
       getNote: jest.fn().mockResolvedValue({ id: 'cat1', note: 'Category note' }),
       updateNote: jest.fn().mockResolvedValue(undefined),
       shutdown: jest.fn(),
@@ -902,6 +906,20 @@ describe('Budget Module', () => {
       const budgets = await budget.getBudgets();
       expect(budgets).toHaveLength(1);
       expect(budgets[0].id).toBe('budget1');
+    });
+
+    it('should get budget preferences', async () => {
+      const preferences = await budget.getPreferences();
+      expect(mockActualApi.getPreferences).toHaveBeenCalled();
+      expect(preferences).toEqual({
+        dateFormat: 'MM/dd/yyyy',
+        numberFormat: 'comma-dot',
+      });
+    });
+
+    it('should propagate errors from getPreferences', async () => {
+      mockActualApi.getPreferences.mockRejectedValueOnce(new Error('No budget file is open'));
+      await expect(budget.getPreferences()).rejects.toThrow('No budget file is open');
     });
   });
 

--- a/__tests__/v1/routes/settings.test.js
+++ b/__tests__/v1/routes/settings.test.js
@@ -33,6 +33,11 @@ describe('Settings Routes', () => {
         maxMonthsOfHistory: 24,
       }),
       exportBudget: jest.fn().mockResolvedValue('exported-data'),
+      getPreferences: jest.fn().mockResolvedValue({
+        dateFormat: 'MM/dd/yyyy',
+        numberFormat: 'comma-dot',
+        hideFraction: 'false',
+      }),
     };
 
     mockReq = {
@@ -104,6 +109,63 @@ describe('Settings Routes', () => {
       await handler(mockReq, mockRes, mockNext);
 
       expect(mockNext).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('GET /budgets/:budgetSyncId/preferences', () => {
+    it('should register the route', () => {
+      const settingsModule = require('../../../src/v1/routes/settings');
+      settingsModule(mockRouter);
+
+      expect(mockRouter.get).toHaveBeenCalledWith(
+        '/budgets/:budgetSyncId/preferences',
+        expect.any(Function)
+      );
+    });
+
+    it('should return the budget preferences', async () => {
+      const settingsModule = require('../../../src/v1/routes/settings');
+      settingsModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/preferences'];
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockBudget.getPreferences).toHaveBeenCalled();
+      expect(mockRes.json).toHaveBeenCalledWith({
+        data: {
+          dateFormat: 'MM/dd/yyyy',
+          numberFormat: 'comma-dot',
+          hideFraction: 'false',
+        },
+      });
+    });
+
+    it('should return an empty object when no preferences are set', async () => {
+      const settingsModule = require('../../../src/v1/routes/settings');
+      settingsModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/preferences'];
+      mockBudget.getPreferences.mockResolvedValueOnce({});
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockRes.json).toHaveBeenCalledWith({ data: {} });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should forward errors to next', async () => {
+      const settingsModule = require('../../../src/v1/routes/settings');
+      settingsModule(mockRouter);
+
+      const handler = handlers['GET /budgets/:budgetSyncId/preferences'];
+      const error = new Error('No budget file is open');
+      mockBudget.getPreferences.mockRejectedValueOnce(error);
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
+      expect(mockRes.json).not.toHaveBeenCalled();
     });
   });
 

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -342,6 +342,10 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     return actualApi.getServerVersion();
   }
 
+  async function getPreferences() {
+    return actualApi.getPreferences();
+  }
+
   async function getIDByName(type, name) {
     return actualApi.getIDByName(type, name);
   }
@@ -501,6 +505,7 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
     deleteSchedule: deleteSchedule,
     getBudgets: getBudgets,
     getServerVersion: getServerVersion,
+    getPreferences: getPreferences,
     getIDByName: getIDByName,
     getTags: getTags,
     createTag: createTag,

--- a/src/v1/routes/settings.js
+++ b/src/v1/routes/settings.js
@@ -193,6 +193,51 @@ module.exports = (router) => {
 
   /**
    * @swagger
+   * /budgets/{budgetSyncId}/preferences:
+   *   get:
+   *     summary: Returns the budget's synced preferences, such as its date, number and currency formats
+   *     tags: [Settings]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - $ref: '#/components/parameters/budgetSyncId'
+   *       - $ref: '#/components/parameters/budgetEncryptionPassword'
+   *     responses:
+   *       '200':
+   *         description: The budget's preferences, as a map of preference id to value. Values are always strings, including booleans and numbers. The set of keys present depends on which preferences have been set for the budget, so callers should treat any individual key as optional
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: object
+   *                   additionalProperties:
+   *                     type: string
+   *               examples:
+   *                 - data:
+   *                     dateFormat: 'MM/dd/yyyy'
+   *                     numberFormat: 'comma-dot'
+   *                     hideFraction: 'false'
+   *                     firstDayOfWeekIdx: '0'
+   *                     budgetType: 'rollover'
+   *       '404':
+   *         $ref: '#/components/responses/404'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   */
+  router.get('/budgets/:budgetSyncId/preferences', async (req, res, next) => {
+    try {
+      res.json({ data: await res.locals.budget.getPreferences() });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  /**
+   * @swagger
    * /budgets/{budgetSyncId}/export:
    *   get:
    *     summary: "(⚠️ Unofficial) Exports the budget data as a zip file containing db.sqlite and metadata.json files."


### PR DESCRIPTION
Independent of #121, #123 and #125 - `getPreferences` landed in 26.8.0, so this works against the currently pinned `^26.8.1`.

26.8.0 added `getPreferences()` to `@actual-app/api`, exposing a budget's synced preferences (date format, number format, currency and friends). It had no HTTP endpoint.

## New endpoint

| Method | Path |
|---|---|
| `GET` | `/budgets/{budgetSyncId}/preferences` |

```json
{
  "data": {
    "dateFormat": "MM/dd/yyyy",
    "numberFormat": "comma-dot",
    "hideFraction": "false",
    "firstDayOfWeekIdx": "0",
    "budgetType": "rollover"
  }
}
```

## Changes

- `src/v1/budget.js`: `getPreferences` wrapper
- `src/v1/routes/settings.js`: the endpoint, alongside the other budget-level settings routes
- `__tests__/v1/budget.test.js`, `__tests__/v1/routes/settings.test.js`: tests

## A note on the response shape

Underneath, this reads `SELECT id, value FROM preferences` and reduces it into an object, so:

- it is a **key/value map, not a fixed schema** - documented with `additionalProperties: { type: string }` rather than named properties
- **every value is a string**, including booleans and numbers (`hideFraction` comes back as `"false"`, `firstDayOfWeekIdx` as `"0"`). I deliberately did not coerce these - there is no type information available to do it correctly, and guessing would be worse than handing callers the raw values
- **which keys are present depends on what has been set** for that budget, so callers should treat any individual key as optional. A budget with nothing set returns `{}`, which is covered by a test

I picked the example keys by reading the values the library actually writes (`dateFormat`, `numberFormat`, `hideFraction`, `firstDayOfWeekIdx`, `budgetType`) rather than inventing plausible-looking ones.

## Why it is not behind the experimental gate

The export endpoint sits behind `experimentalOperationsEnabled`. This one is read-only and touches no internals, so I left it ungated like the other read endpoints. Easy to change if you would rather it were gated.

## Testing

`npm test` - 416 passed, 19 suites (410 before, +6). Also confirmed the route mounts on the shared router and the path resolves in the generated Swagger spec.