### PR TITLE
Expose importBudget as POST /budgets/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ Notes:
 
 - `EXPERIMENTAL_OPERATIONS_ENABLED` (optional) — Toggle to enable experimental endpoints that rely on Actual internals. Defaults to enabled (true). Set to `false` to disable these endpoints; when disabled the HTTP server will respond with `501 Not Implemented` for those operations and they will be hidden from the Swagger UI.
 
+### Importing a budget
+
+`POST /v1/budgets/import` accepts an Actual export or a YNAB4/YNAB5 file as the raw request body, with `Content-Type: application/zip` or `application/octet-stream`, and returns the sync id of the imported budget.
+
+Importing a budget that already exists does **not** restore it in place. The Actual library clears the file's server identity on import, so the budget is uploaded to your Actual server as a new file and receives a **new sync id**. The original budget and its sync id are left untouched, so you end up with two budgets rather than one. Use the `syncId` returned in the response to address the imported budget.
+
+```bash
+curl -X POST 'http://localhost:5007/v1/budgets/import?type=actual' \
+  -H 'x-api-key: your-api-key' \
+  -H 'Content-Type: application/zip' \
+  --data-binary '@2026-09-06-My-Budget.zip'
+```
+
 ## Documentation
 
 When running locally with default port mapping, open:

--- a/__tests__/v1/budget.test.js
+++ b/__tests__/v1/budget.test.js
@@ -13,7 +13,7 @@ jest.mock('../../src/utils/utils');
 jest.mock('fs');
 jest.mock('path');
 
-const { Budget } = require('../../src/v1/budget');
+const { Budget, importBudgetData } = require('../../src/v1/budget');
 const { getActualApiClient, getActualDataDir, runAqlQuery } = require('../../src/v1/actual-client-provider');
 const { 
   currentLocalDate, 
@@ -982,6 +982,112 @@ describe('Budget Module', () => {
     it('should propagate errors from getPreferences', async () => {
       mockActualApi.getPreferences.mockRejectedValueOnce(new Error('No budget file is open'));
       await expect(budget.getPreferences()).rejects.toThrow('No budget file is open');
+    });
+  });
+
+  describe('Data Import', () => {
+    beforeEach(() => {
+      mockActualApi.importBudget = jest.fn().mockResolvedValue({ id: 'My-Finances-5e3e565' });
+      mockActualApi.getBudgets.mockResolvedValue([
+        {
+          id: 'My-Finances-5e3e565',
+          cloudFileId: '4dc8876b-e7e4-4e5c-ab69-8215242c279c',
+          groupId: 'a232c399-e28c-4a51-96be-d1183129d1f9',
+          name: 'Actual Bench Test'
+        }
+      ]);
+    });
+
+    it('should import the budget and return its new sync id', async () => {
+      const fileBuffer = Buffer.from([1, 2, 3]);
+
+      const result = await importBudgetData(fileBuffer, { type: 'actual' });
+
+      expect(mockActualApi.importBudget).toHaveBeenCalledWith(fileBuffer, {
+        type: 'actual',
+        filename: undefined
+      });
+      expect(result).toEqual({
+        id: 'My-Finances-5e3e565',
+        syncId: 'a232c399-e28c-4a51-96be-d1183129d1f9',
+        name: 'Actual Bench Test'
+      });
+    });
+
+    it('should default the type to actual', async () => {
+      await importBudgetData(Buffer.from([1, 2, 3]));
+
+      expect(mockActualApi.importBudget).toHaveBeenCalledWith(expect.any(Buffer), {
+        type: 'actual',
+        filename: undefined
+      });
+    });
+
+    it('should forward the type and filename for YNAB imports', async () => {
+      await importBudgetData(Buffer.from([1, 2, 3]), { type: 'ynab5', filename: 'budget.json' });
+
+      expect(mockActualApi.importBudget).toHaveBeenCalledWith(expect.any(Buffer), {
+        type: 'ynab5',
+        filename: 'budget.json'
+      });
+    });
+
+    it('should fail when the imported budget has no sync id, meaning the upload did not reach the server', async () => {
+      mockActualApi.getBudgets.mockResolvedValue([
+        { id: 'My-Finances-5e3e565', name: 'Actual Bench Test' }
+      ]);
+
+      await expect(importBudgetData(Buffer.from([1, 2, 3]), { type: 'actual' }))
+        .rejects
+        .toThrow('could not be uploaded to the Actual server');
+    });
+
+    it('should fail when the imported budget is missing from the budget list', async () => {
+      mockActualApi.getBudgets.mockResolvedValue([]);
+
+      await expect(importBudgetData(Buffer.from([1, 2, 3]), { type: 'actual' }))
+        .rejects
+        .toThrow('could not be uploaded to the Actual server');
+    });
+
+    it('should ignore remote entries, which carry no id, when resolving the imported budget', async () => {
+      mockActualApi.getBudgets.mockResolvedValue([
+        {
+          cloudFileId: '4dc8876b-e7e4-4e5c-ab69-8215242c279c',
+          state: 'remote',
+          groupId: 'a232c399-e28c-4a51-96be-d1183129d1f9',
+          name: 'Actual Bench Test'
+        }
+      ]);
+
+      await expect(importBudgetData(Buffer.from([1, 2, 3]), { type: 'actual' }))
+        .rejects
+        .toThrow('could not be uploaded to the Actual server');
+    });
+
+    it('should propagate import failures from the official API', async () => {
+      mockActualApi.importBudget.mockRejectedValueOnce(
+        new Error('Error importing budget: not-zip-file')
+      );
+
+      await expect(importBudgetData(Buffer.from([1, 2, 3]), { type: 'actual' }))
+        .rejects
+        .toThrow('Error importing budget: not-zip-file');
+    });
+
+    it('should clear the cached sync id map so a stale entry cannot resolve the wrong budget', async () => {
+      // Populate the cache by loading a budget, then import and confirm the next call
+      // re-downloads instead of reusing the cached budget id
+      await Budget('sync1', undefined);
+      mockActualApi.downloadBudget.mockClear();
+
+      await Budget('sync1', undefined);
+      expect(mockActualApi.downloadBudget).not.toHaveBeenCalled();
+
+      await importBudgetData(Buffer.from([1, 2, 3]), { type: 'actual' });
+
+      await Budget('sync1', undefined);
+      expect(mockActualApi.downloadBudget).toHaveBeenCalledWith('sync1');
     });
   });
 

--- a/__tests__/v1/middlewares/error-handler.test.js
+++ b/__tests__/v1/middlewares/error-handler.test.js
@@ -145,5 +145,44 @@ describe('Error Handler Middleware', () => {
         error: 'Unknown error while interacting with Actual Api. See server logs for more information',
       });
     });
+
+    it.each([
+      'not-zip-file',
+      'invalid-zip-file',
+      'invalid-meta-file',
+      'zip-too-large',
+      'not-ynab4',
+      'not-ynab5',
+    ])('should return 400 for the %s budget import error', (token) => {
+      const err = new Error(`Error importing budget: ${token}`);
+
+      errorHandler(err, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: `Error importing budget: ${token}` });
+    });
+
+    it.each(['internal-error', 'unknown'])(
+      'should keep the %s budget import error as a 500',
+      (token) => {
+        const err = new Error(`Error importing budget: ${token}`);
+
+        errorHandler(err, req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({
+          error: 'Unknown error while interacting with Actual Api. See server logs for more information',
+        });
+      }
+    );
+
+    it('should keep the message when an import cannot be uploaded to the server', () => {
+      const err = new Error('The budget was imported but could not be uploaded to the Actual server, so it has no sync id and is not reachable. Check the Actual Server connection and retry the import, retrying replaces the incomplete copy');
+
+      errorHandler(err, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ error: err.message });
+    });
   });
 });

--- a/__tests__/v1/routes/import.test.js
+++ b/__tests__/v1/routes/import.test.js
@@ -1,0 +1,196 @@
+// Ensure required secrets exist before importing modules that load config at module initialization
+process.env.API_KEY = process.env.API_KEY || 'test-api-key';
+process.env.ACTUAL_SERVER_PASSWORD = process.env.ACTUAL_SERVER_PASSWORD || 'test-password';
+
+jest.mock('../../../src/v1/budget', () => ({
+  importBudgetData: jest.fn(),
+}));
+
+describe('Import Routes', () => {
+  let mockRouter;
+  let mockReq;
+  let mockRes;
+  let mockNext;
+  let handlers;
+  let registrations;
+  let importBudgetData;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    handlers = {};
+    registrations = {};
+
+    // The import route registers middleware alongside its handler, so keep every argument
+    // and treat the last one as the handler
+    mockRouter = {
+      post: jest.fn((path, ...rest) => {
+        handlers[`POST ${path}`] = rest[rest.length - 1];
+        registrations[`POST ${path}`] = rest;
+      }),
+    };
+
+    mockReq = {
+      params: {},
+      query: {},
+      body: Buffer.from([1, 2, 3]),
+    };
+
+    mockRes = {
+      json: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+    };
+
+    mockNext = jest.fn();
+
+    ({ importBudgetData } = require('../../../src/v1/budget'));
+    importBudgetData.mockResolvedValue({
+      id: 'My-Finances-5e3e565',
+      syncId: 'a232c399-e28c-4a51-96be-d1183129d1f9',
+      name: 'Actual Bench Test',
+    });
+  });
+
+  function loadRoute() {
+    require('../../../src/v1/routes/import')(mockRouter);
+    return handlers['POST /budgets/import'];
+  }
+
+  describe('registration', () => {
+    it('should register POST /budgets/import', () => {
+      loadRoute();
+      expect(mockRouter.post).toHaveBeenCalledWith(
+        '/budgets/import',
+        expect.any(Function),
+        expect.any(Function),
+        expect.any(Function)
+      );
+    });
+
+    it('should apply the api key guard, since the route is outside the /budgets/:budgetSyncId prefix', () => {
+      loadRoute();
+      const { authorizeRequest } = require('../../../src/v1/middlewares/api-key-authorization');
+      expect(registrations['POST /budgets/import'][0]).toBe(authorizeRequest);
+    });
+  });
+
+  describe('POST /budgets/import', () => {
+    it('should import the budget and return its new sync id', async () => {
+      const handler = loadRoute();
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(importBudgetData).toHaveBeenCalledWith(mockReq.body, {
+        type: 'actual',
+        filename: undefined,
+      });
+      expect(mockRes.status).toHaveBeenCalledWith(201);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        data: {
+          id: 'My-Finances-5e3e565',
+          syncId: 'a232c399-e28c-4a51-96be-d1183129d1f9',
+          name: 'Actual Bench Test',
+        },
+      });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should default the type to actual', async () => {
+      const handler = loadRoute();
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(importBudgetData).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ type: 'actual' }));
+    });
+
+    it.each(['ynab4', 'ynab5'])('should forward the %s type and filename', async (type) => {
+      const handler = loadRoute();
+      mockReq.query = { type, filename: 'budget.json' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(importBudgetData).toHaveBeenCalledWith(mockReq.body, { type, filename: 'budget.json' });
+      expect(mockRes.status).toHaveBeenCalledWith(201);
+    });
+
+    it('should pass the raw body as a Buffer, never as a path string', async () => {
+      const handler = loadRoute();
+
+      await handler(mockReq, mockRes, mockNext);
+
+      const [fileBuffer] = importBudgetData.mock.calls[0];
+      expect(Buffer.isBuffer(fileBuffer)).toBe(true);
+      expect(typeof fileBuffer).not.toBe('string');
+    });
+
+    it('should reject an unknown type', async () => {
+      const handler = loadRoute();
+      mockReq.query = { type: 'quicken' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(importBudgetData).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'type must be one of: actual, ynab4, ynab5',
+      }));
+    });
+
+    it('should reject an empty body', async () => {
+      const handler = loadRoute();
+      mockReq.body = Buffer.alloc(0);
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(importBudgetData).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'A budget file is required as the raw request body',
+      }));
+    });
+
+    it('should reject a body that is not a Buffer', async () => {
+      const handler = loadRoute();
+      mockReq.body = { budget: 'not a buffer' };
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(importBudgetData).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'A budget file is required as the raw request body',
+      }));
+    });
+
+    it('should forward errors to the error handler', async () => {
+      const handler = loadRoute();
+      const error = new Error('Error importing budget: not-zip-file');
+      importBudgetData.mockRejectedValueOnce(error);
+
+      await handler(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+
+    it('should return 501 when experimental operations are disabled', async () => {
+      jest.resetModules();
+      jest.doMock('../../../src/config/config', () => ({
+        config: { experimentalOperationsEnabled: false },
+      }));
+
+      const localHandlers = {};
+      const localRouter = {
+        post: jest.fn((path, ...rest) => {
+          localHandlers[`POST ${path}`] = rest[rest.length - 1];
+        }),
+      };
+      require('../../../src/v1/routes/import')(localRouter);
+
+      await localHandlers['POST /budgets/import'](mockReq, mockRes, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(501);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: 'This operation is experimental and is currently disabled.',
+      });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/v1/routes/index.test.js
+++ b/__tests__/v1/routes/index.test.js
@@ -2,7 +2,8 @@ const request = require('supertest');
 const express = require('express');
 
 jest.mock('../../../src/v1/budget', () => ({
-  Budget: jest.fn()
+  Budget: jest.fn(),
+  importBudgetData: jest.fn()
 }));
 
 jest.mock('../../../src/v1/middlewares/api-key-authorization', () => ({
@@ -51,5 +52,35 @@ describe('index.js router', () => {
 
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'Boom!' });
+  });
+
+  // The /budgets/:budgetSyncId middleware matches any path with a second segment, so it would
+  // capture /budgets/import with budgetSyncId set to the literal string "import". The import
+  // route is registered before that middleware to prevent it; this guards the ordering.
+  test('POST /budgets/import reaches the import route instead of the budget middleware', async () => {
+    const { Budget, importBudgetData } = require('../../../src/v1/budget');
+    importBudgetData.mockResolvedValue({
+      id: 'My-Finances-5e3e565',
+      syncId: 'a232c399-e28c-4a51-96be-d1183129d1f9',
+      name: 'Actual Bench Test'
+    });
+
+    const app = createApp();
+
+    const res = await request(app)
+      .post('/budgets/import')
+      .set('Content-Type', 'application/zip')
+      .send(Buffer.from([1, 2, 3]));
+
+    expect(Budget).not.toHaveBeenCalled();
+    expect(importBudgetData).toHaveBeenCalled();
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({
+      data: {
+        id: 'My-Finances-5e3e565',
+        syncId: 'a232c399-e28c-4a51-96be-d1183129d1f9',
+        name: 'Actual Bench Test'
+      }
+    });
   });
 });

--- a/src/v1/budget.js
+++ b/src/v1/budget.js
@@ -7,6 +7,32 @@ const path = require('path');
 
 let syncIdToBudgetId = {};
 
+function clearSyncIdToBudgetIdCache() {
+  syncIdToBudgetId = {};
+}
+
+async function importBudgetData(fileBuffer, { type = 'actual', filename } = {}) {
+  const actualApi = await getActualApiClient();
+
+  const { id } = await actualApi.importBudget(fileBuffer, { type, filename });
+
+  // The imported budget gets a new sync id, so any cached entry for it is now stale
+  clearSyncIdToBudgetIdCache();
+
+  // The library swallows upload failures, leaving the budget on disk with no sync id and
+  // unreachable from every other endpoint, so treat that as a failed import
+  const importedBudget = (await actualApi.getBudgets() || []).find(budget => budget.id === id && budget.groupId);
+  if (!importedBudget) {
+    throw new Error('The budget was imported but could not be uploaded to the Actual server, so it has no sync id and is not reachable. Check the Actual Server connection and retry the import, retrying replaces the incomplete copy');
+  }
+
+  return {
+    id,
+    syncId: importedBudget.groupId,
+    name: importedBudget.name
+  };
+}
+
 async function Budget(budgetSyncId, budgetEncryptionPassword) {
   const actualApi = await getActualApiClient();
   if (budgetSyncId in syncIdToBudgetId) {
@@ -539,3 +565,5 @@ async function Budget(budgetSyncId, budgetEncryptionPassword) {
 }
 
 exports.Budget = Budget;
+exports.importBudgetData = importBudgetData;
+exports.clearSyncIdToBudgetIdCache = clearSyncIdToBudgetIdCache;

--- a/src/v1/middlewares/error-handler.js
+++ b/src/v1/middlewares/error-handler.js
@@ -27,8 +27,17 @@ const errorHandler = (err, req, res, next) => {
     || err.message.includes('does not exist on table')
     || err.message.includes('convert to integer')
     || err.message.includes('must be')
+    // Errors the Actual library reports for an unusable uploaded budget file
+    || err.message.includes('not-zip-file')
+    || err.message.includes('invalid-zip-file')
+    || err.message.includes('invalid-meta-file')
+    || err.message.includes('zip-too-large')
+    || err.message.includes('not-ynab4')
+    || err.message.includes('not-ynab5')
   ) {
     clientError(res, 400, err, err.message);
+  } else if (err.message.includes('could not be uploaded to the Actual server')) {
+    serverError(res, err, err.message);
   } else {
     serverError(res, err, 'Unknown error while interacting with Actual Api. See server logs for more information');
   }

--- a/src/v1/routes/import.js
+++ b/src/v1/routes/import.js
@@ -1,0 +1,113 @@
+const express = require('express');
+const { importBudgetData } = require('../budget');
+const { authorizeRequest } = require('../middlewares/api-key-authorization');
+
+const IMPORT_TYPES = ['actual', 'ynab4', 'ynab5'];
+
+// ynab5 files are JSON, but are read as raw bytes here because the global express.json()
+// in server.js would otherwise parse them into an object before this route runs
+const IMPORT_CONTENT_TYPES = ['application/zip', 'application/x-zip-compressed', 'application/octet-stream'];
+
+const IMPORT_MAX_SIZE = '500mb';
+
+module.exports = (router) => {
+  const { config } = require('../../config/config');
+  const { EXPERIMENTAL_DISABLED_MESSAGE } = require('./constants');
+  /**
+   * @swagger
+   * /budgets/import:
+   *   post:
+   *     summary: "(🔧 Extended) Imports a budget from an Actual export or a YNAB4/YNAB5 file."
+   *     description: "🔧 Extended: Uses the official importBudget API, returning the sync id of the imported budget.
+   *       Note that importing a budget that already exists does not restore it in place: the Actual library clears the
+   *       file's server identity on import, so the budget is uploaded as a new file and receives a NEW sync id. The
+   *       original budget and its sync id are left untouched."
+   *     tags: [Settings]
+   *     security:
+   *       - apiKey: []
+   *     parameters:
+   *       - name: type
+   *         in: query
+   *         required: false
+   *         schema:
+   *           type: string
+   *           enum: [actual, ynab4, ynab5]
+   *           default: actual
+   *         description: The format of the uploaded file
+   *       - name: filename
+   *         in: query
+   *         required: false
+   *         schema:
+   *           type: string
+   *         description: Used to derive the budget name when importing YNAB files
+   *     requestBody:
+   *       required: true
+   *       description: The raw budget file. Actual and YNAB4 exports are zip files, YNAB5 exports are JSON
+   *       content:
+   *         application/zip:
+   *           schema:
+   *             type: string
+   *             format: binary
+   *         application/octet-stream:
+   *           schema:
+   *             type: string
+   *             format: binary
+   *     responses:
+   *       '201':
+   *         description: The imported budget
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - data
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   required:
+   *                     - id
+   *                     - syncId
+   *                     - name
+   *                   type: object
+   *                   properties:
+   *                     id:
+   *                       type: string
+   *                     syncId:
+   *                       type: string
+   *                       description: The sync id of the imported budget, used by every other endpoint
+   *                     name:
+   *                       type: string
+   *               examples:
+   *                 - data:
+   *                     id: 'My-Finances-5e3e565'
+   *                     syncId: 'a232c399-e28c-4a51-96be-d1183129d1f9'
+   *                     name: 'Actual Bench Test'
+   *       '400':
+   *         $ref: '#/components/responses/400'
+   *       '500':
+   *         $ref: '#/components/responses/500'
+   *       '501':
+   *         $ref: '#/components/responses/501'
+   */
+  router.post('/budgets/import',
+    authorizeRequest,
+    express.raw({ type: IMPORT_CONTENT_TYPES, limit: IMPORT_MAX_SIZE }),
+    async (req, res, next) => {
+      try {
+        if (!config.experimentalOperationsEnabled) {
+          return res.status(501).json({ error: EXPERIMENTAL_DISABLED_MESSAGE });
+        }
+        const type = req.query.type || 'actual';
+        if (!IMPORT_TYPES.includes(type)) {
+          throw new Error(`type must be one of: ${IMPORT_TYPES.join(', ')}`);
+        }
+        if (!Buffer.isBuffer(req.body) || req.body.length === 0) {
+          throw new Error('A budget file is required as the raw request body');
+        }
+        res.status(201).json({
+          data: await importBudgetData(req.body, { type, filename: req.query.filename })
+        });
+      } catch (err) {
+        next(err);
+      }
+    });
+};

--- a/src/v1/routes/index.js
+++ b/src/v1/routes/index.js
@@ -6,6 +6,11 @@ const { config } = require('../../config/config');
 
 const router = express.Router();
 
+// Must be registered before the /budgets/:budgetSyncId middleware below, otherwise
+// :budgetSyncId captures the literal string "import" and the request is treated as a
+// request for a budget with that sync id. This route applies authorizeRequest itself.
+require('./import')(router);
+
 router.use('/budgets/:budgetSyncId', authorizeRequest, async (req, res, next) => {
     try {
       if (config.allowedBudgetSyncIds && !config.allowedBudgetSyncIds.includes(req.params.budgetSyncId)) {


### PR DESCRIPTION
Completes the round trip with `GET /budgets/{budgetSyncId}/export` (#125). Accepts an Actual export or a YNAB4/YNAB5 file as the raw request body and returns the sync id of the imported budget. No new dependency.

Changes:
- `src/v1/routes/import.js`: new route, `POST /budgets/import`
- `src/v1/routes/index.js`: registers it above the budget middleware
- `src/v1/budget.js`: `importBudgetData` + `clearSyncIdToBudgetIdCache`
- `src/v1/middlewares/error-handler.js`: maps the library's file format errors to 400
- `README.md`: usage and the new-sync-id caveat
- `__tests__/`: 30 new tests, 469 passing

Three things worth a look in review:

1. **Route placement.** `router.use('/budgets/:budgetSyncId', ...)` matches any path with a second segment, so `/budgets/import` would be captured with `budgetSyncId = "import"`. The route is registered before that middleware and applies `authorizeRequest` itself, since `authorizeRequest` is only attached to the `:budgetSyncId` prefix. There's a supertest guard in `index.test.js` so a future reorder fails the build rather than silently breaking the endpoint.

2. **Failed uploads are failures, not partial successes.** `importActual` calls `upload().catch(() => {})`, so a network failure leaves the budget on disk with no sync id, unreachable from every other endpoint. The route re-reads `getBudgets()` and errors if the imported budget has no `groupId`. Retrying is safe: the budget id comes from the file, so it replaces the incomplete copy.

3. **The error-handler change is deliberately narrow.** I considered a generic `if (err.status >= 400)` branch, but `express.json()` already throws parse errors carrying `status: 400`, so that would have changed what every existing endpoint returns for malformed JSON. Instead it's a message match in the file's existing idiom. Tests assert `internal-error` and `unknown` still map to 500 and that the existing 400/404/500 cases are unchanged.

Note on behaviour, documented in the README and Swagger: importing a budget that already exists does not restore it in place. `importActual` clears the file's server identity (`{ cloudFileId: null, groupId: null }`), so the budget is uploaded as a new file and gets a NEW sync id, leaving the original untouched. This matches Actual's own import, which performs no conflict check either.
